### PR TITLE
Implement per-file language handling for SDLTM

### DIFF
--- a/gui/widgets/file_list.py
+++ b/gui/widgets/file_list.py
@@ -24,6 +24,15 @@ class FileListItem(QWidget):
         self.file_info = file_info
         self.setup_ui()
 
+    def update_languages(self, languages: Dict[str, str]):
+        """Обновляет отображение языков"""
+        self.file_info['languages'] = languages
+        info_parts = self.info_label.text().split(' • ')
+        # remove existing language info if present
+        info_parts = [p for p in info_parts if '→' not in p]
+        info_parts.append(f"{languages['source']}→{languages['target']}")
+        self.info_label.setText(' • '.join(info_parts))
+
     def setup_ui(self):
         """Настройка интерфейса"""
         # Основной макет с уменьшенными отступами
@@ -89,6 +98,10 @@ class FileListItem(QWidget):
 
         if self.file_info['extra_info']:
             info_parts.append(self.file_info['extra_info'])
+
+        if self.file_info.get('languages'):
+            langs = self.file_info['languages']
+            info_parts.append(f"{langs['source']}→{langs['target']}")
 
         info_text = " • ".join(info_parts)
 
@@ -382,6 +395,12 @@ class FileListWidget(QWidget):
     def get_file_item(self, filepath: Path) -> FileListItem:
         """Возвращает виджет файла"""
         return self.file_items.get(filepath)
+
+    def set_file_languages(self, filepath: Path, languages: Dict[str, str]):
+        """Обновляет языки для файла"""
+        file_item = self.get_file_item(filepath)
+        if file_item:
+            file_item.update_languages(languages)
 
     def set_file_progress(self, filepath: Path, progress: int, message: str = ""):
         """Устанавливает прогресс для файла"""

--- a/gui/windows/main_window.py
+++ b/gui/windows/main_window.py
@@ -615,7 +615,7 @@ class MainWindow(QMainWindow):
         self.file_list.reset_all_status()
 
         # Запускаем конвертацию через worker
-        self.manager.start_batch(files, options)
+        self.manager.start_batch(files, options, self.controller.get_file_language_mapping())
         self.log_message(f"🚀 Начата конвертация {len(files)} файлов")
 
     def stop_conversion(self):
@@ -638,7 +638,8 @@ class MainWindow(QMainWindow):
                 'size_mb': file_info['size_mb'],
                 'format': file_info['format'],
                 'format_icon': file_info['format_icon'],
-                'extra_info': file_info['extra_info']
+                'extra_info': file_info['extra_info'],
+                'languages': self.controller.get_file_languages(filepath)
             })
 
         self.file_list.update_files(files_info)
@@ -646,9 +647,12 @@ class MainWindow(QMainWindow):
     def _update_auto_languages_display(self):
         """Обновляет отображение автоопределенных языков"""
         languages = self.controller.get_auto_detected_languages()
+        src_file = self.controller.auto_language_source
 
         if languages:
             lang_text = f"{languages['source']} → {languages['target']}"
+            if src_file:
+                lang_text += f" ({Path(src_file).name})"
             self.auto_langs_label.setText(lang_text)
             self.auto_langs_label.setStyleSheet("color: #4CAF50; font-weight: bold;")
         else:

--- a/services/conversion_manager.py
+++ b/services/conversion_manager.py
@@ -39,9 +39,9 @@ class ConversionManager(QObject):
 
         self._excel_workers: List[ExcelConversionWorker] = []
 
-    def start_batch(self, files: List[Path], options):
+    def start_batch(self, files: List[Path], options, file_languages=None):
         """Start batch conversion."""
-        self._batch_worker.convert_batch(files, options)
+        self._batch_worker.convert_batch(files, options, file_languages)
 
     def stop_all(self):
         """Stop all running conversions."""

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+from controller import MainController
+
+def test_set_get_file_languages():
+    c = MainController()
+    fake = Path('a.sdltm')
+    c.files.append(fake)
+    c.set_file_languages(fake, 'en-US', 'de-DE')
+    langs = c.get_file_languages(fake)
+    assert langs == {'source': 'en-US', 'target': 'de-DE'}


### PR DESCRIPTION
## Summary
- track detected languages per SDLTM file
- surface file languages in the UI list
- show which file provided auto-detected languages
- allow per-file language overrides during conversion
- expose utilities for file languages in controller
- adjust workers and manager to use per-file settings
- add unit test for controller language management

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869a789f4f8832cbd14c5080ed4fe0c