### PR TITLE
Add manual language selection for TM files

### DIFF
--- a/gui/dialogs/__init__.py
+++ b/gui/dialogs/__init__.py
@@ -1,0 +1,3 @@
+from .excel_config_dialog import ExcelConfigDialog
+from .language_dialog import LanguageDialog
+__all__ = ["ExcelConfigDialog", "LanguageDialog"]

--- a/gui/dialogs/language_dialog.py
+++ b/gui/dialogs/language_dialog.py
@@ -1,0 +1,38 @@
+from PySide6.QtWidgets import (
+    QDialog, QVBoxLayout, QFormLayout, QLineEdit,
+    QHBoxLayout, QPushButton
+)
+from PySide6.QtCore import Qt
+
+
+class LanguageDialog(QDialog):
+    """Диалог ручной настройки языков"""
+
+    def __init__(self, source: str = "", target: str = "", parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Языки файла")
+        self.source = source
+        self.target = target
+        self.setup_ui()
+
+    def setup_ui(self):
+        layout = QVBoxLayout(self)
+        form = QFormLayout()
+        self.src_edit = QLineEdit(self.source)
+        self.tgt_edit = QLineEdit(self.target)
+        form.addRow("Исходный:", self.src_edit)
+        form.addRow("Целевой:", self.tgt_edit)
+        layout.addLayout(form)
+
+        buttons = QHBoxLayout()
+        ok_btn = QPushButton("OK")
+        cancel_btn = QPushButton("Отмена")
+        ok_btn.clicked.connect(self.accept)
+        cancel_btn.clicked.connect(self.reject)
+        buttons.addStretch()
+        buttons.addWidget(cancel_btn)
+        buttons.addWidget(ok_btn)
+        layout.addLayout(buttons)
+
+    def get_languages(self) -> tuple[str, str]:
+        return self.src_edit.text().strip(), self.tgt_edit.text().strip()

--- a/gui/widgets/file_list.py
+++ b/gui/widgets/file_list.py
@@ -17,12 +17,17 @@ class FileListItem(QWidget):
     """Виджет для отображения файла"""
 
     remove_requested = Signal(Path)
+    double_clicked = Signal(Path)
 
     def __init__(self, file_info: Dict):
         super().__init__()
         self.filepath = file_info['path']
         self.file_info = file_info
         self.setup_ui()
+
+    def mouseDoubleClickEvent(self, event):
+        self.double_clicked.emit(self.filepath)
+        super().mouseDoubleClickEvent(event)
 
     def update_languages(self, languages: Dict[str, str]):
         """Обновляет отображение языков"""
@@ -207,6 +212,7 @@ class FileListWidget(QWidget):
 
     files_changed = Signal(int)
     file_remove_requested = Signal(Path)
+    file_language_edit_requested = Signal(Path)
 
     def __init__(self):
         super().__init__()
@@ -275,9 +281,9 @@ class FileListWidget(QWidget):
             }
         """)
 
-        # Отключаем стандартное выделение
-        self.list_widget.setSelectionMode(QListWidget.NoSelection)
-        self.list_widget.setFocusPolicy(Qt.NoFocus)
+        # Позволяем выделять элементы для ручной настройки
+        self.list_widget.setSelectionMode(QListWidget.SingleSelection)
+        self.list_widget.setFocusPolicy(Qt.StrongFocus)
 
         # Убираем минимальный размер
         self.list_widget.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
@@ -337,6 +343,7 @@ class FileListWidget(QWidget):
         # Создаем виджет для файла
         file_item = FileListItem(file_info)
         file_item.remove_requested.connect(self.file_remove_requested.emit)
+        file_item.double_clicked.connect(self.file_language_edit_requested.emit)
 
         # Создаем элемент списка
         list_item = QListWidgetItem()


### PR DESCRIPTION
## Summary
- implement `LanguageDialog` to edit source and target languages
- allow selecting files in the file list and open language dialog on double click
- connect file list signal to main window for manual language editing
- remove the visible auto-detected languages row from conversion settings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a5fb155c0832c926658b28b34fc76