### PR TITLE
Fix language override and progress updates

### DIFF
--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -1,4 +1,27 @@
 import pytest
 
-def test_placeholder():
-    assert True
+import sqlite3
+from core.converters.sdltm import SdltmConverter
+from core.base import ConversionOptions
+
+
+def test_language_override_in_streaming(tmp_path):
+    db_path = tmp_path / "mem.sdltm"
+
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "CREATE TABLE translation_units (source_segment TEXT, target_segment TEXT)"
+        )
+        src_xml = '<segment><Text><Value>Hello</Value></Text><CultureName>en-US</CultureName></segment>'
+        tgt_xml = '<segment><Text><Value>Salut</Value></Text><CultureName>fr-FR</CultureName></segment>'
+        conn.execute(
+            "INSERT INTO translation_units (source_segment, target_segment) VALUES (?, ?)",
+            (src_xml, tgt_xml),
+        )
+
+    conv = SdltmConverter()
+    opts = ConversionOptions(source_lang="de-DE", target_lang="ru-RU", export_tmx=False, export_xlsx=False)
+    segs = list(conv.convert_streaming(db_path, opts))
+
+    assert segs[0][2].lower() == "de-de"
+    assert segs[0][3].lower() == "ru-ru"

--- a/workers/conversion_worker.py
+++ b/workers/conversion_worker.py
@@ -246,6 +246,11 @@ class ConversionWorker(QObject):
         with QMutexLocker(self.mutex):
             self.current_progress = progress
             self.current_message = message
+            emit_progress = progress
+            emit_message = message
+
+        # Мгновенно отправляем обновление, чтобы индикатор не зависал
+        self.progress_changed.emit(emit_progress, emit_message)
 
     def _emit_progress_update(self):
         """Эмитит обновление прогресса"""


### PR DESCRIPTION
## Summary
- respect user-specified languages during SDLTM export
- update streaming conversion accordingly
- emit progress updates immediately so progress bar doesn't freeze
- cover language override in unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a6d748e50832c8d720ffaa6a13721