### PR TITLE
Fix window size changing during export

### DIFF
--- a/gui/widgets/file_list.py
+++ b/gui/widgets/file_list.py
@@ -151,6 +151,7 @@ class FileListItem(QWidget):
                 padding: 1px;
             }
         """)
+        self.status_label.setWordWrap(True)
         self.status_label.setVisible(False)
         main_layout.addWidget(self.status_label)
 

--- a/gui/widgets/progress_widget.py
+++ b/gui/widgets/progress_widget.py
@@ -2,7 +2,7 @@
 
 from PySide6.QtWidgets import (
     QWidget, QVBoxLayout, QHBoxLayout, QProgressBar,
-    QLabel, QGroupBox
+    QLabel, QGroupBox, QSizePolicy
 )
 from PySide6.QtCore import Signal, Qt, QTimer, QPropertyAnimation, QEasingCurve, QMutex, QMutexLocker
 from PySide6.QtGui import QFont
@@ -65,6 +65,8 @@ class ProgressWidget(QWidget):
         # Текущий статус
         self.status_label = QLabel("Готов к работе")
         self.status_label.setStyleSheet(STATUS_LABEL_STYLE)
+        self.status_label.setWordWrap(True)
+        self.status_label.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Preferred)
         info_layout.addWidget(self.status_label)
 
         info_layout.addStretch()


### PR DESCRIPTION
## Summary
- ensure progress status labels wrap text so the window doesn't resize

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a82493c60832cb8dc834e5603986a