### PR TITLE
Support SDLXLIFF files

### DIFF
--- a/gui/widgets/drop_area.py
+++ b/gui/widgets/drop_area.py
@@ -72,7 +72,7 @@ class SmartDropArea(QWidget):
         layout.addWidget(self.format_label)
 
         # Список поддерживаемых форматов
-        formats_text = "SDLTM, Excel, TMX, XML/TB"
+        formats_text = "SDLTM, SDLXLIFF, Excel, TMX, XML/TB"
         self.formats_label = QLabel(formats_text)
         self.formats_label.setAlignment(Qt.AlignCenter)
         self.formats_label.setStyleSheet("""
@@ -184,8 +184,9 @@ class SmartDropArea(QWidget):
             self,
             "Выберите файлы для конвертации",
             "",
-            "Все поддерживаемые (*.sdltm *.xlsx *.xls *.tmx *.xml *.mtf *.tbx);;"
+            "Все поддерживаемые (*.sdltm *.sdxliff *.sdlxliff *.xlsx *.xls *.tmx *.xml *.mtf *.tbx);;"
             "SDLTM (*.sdltm);;"
+            "SDLXLIFF (*.sdxliff *.sdlxliff);;"
             "Excel (*.xlsx *.xls);;"
             "TMX (*.tmx);;"
             "XML/Termbase (*.xml *.mtf *.tbx)"

--- a/gui/windows/main_window.py
+++ b/gui/windows/main_window.py
@@ -393,7 +393,7 @@ class MainWindow(QMainWindow):
             self,
             "Выберите файлы для конвертации",
             "",
-            "Все поддерживаемые (*.sdltm *.xlsx *.xls *.tmx *.xml *.mtf *.tbx);;SDLTM (*.sdltm);;Excel (*.xlsx *.xls);;TMX (*.tmx);;XML/Termbase (*.xml *.mtf *.tbx)"
+            "Все поддерживаемые (*.sdltm *.sdxliff *.sdlxliff *.xlsx *.xls *.tmx *.xml *.mtf *.tbx);;SDLTM (*.sdltm);;SDLXLIFF (*.sdxliff *.sdlxliff);;Excel (*.xlsx *.xls);;TMX (*.tmx);;XML/Termbase (*.xml *.mtf *.tbx)"
         )
 
         if files:

--- a/services/file_service.py
+++ b/services/file_service.py
@@ -16,6 +16,7 @@ class FileService:
         self.supported_formats = {
             '.sdltm': 'SDL Trados Memory',
             '.sdxliff': 'SDXLIFF File',
+            '.sdlxliff': 'SDXLIFF File',
             '.xlsx': 'Excel Workbook',
             '.xls': 'Excel Workbook',
             '.tmx': 'TMX Memory',
@@ -42,7 +43,7 @@ class FileService:
                 info['extra_info'] = self._get_sdltm_info(filepath)
             elif suffix in ['.xlsx', '.xls']:
                 info['extra_info'] = self._get_excel_info(filepath)
-            elif suffix == '.sdxliff':
+            elif suffix in ['.sdxliff', '.sdlxliff']:
                 info['extra_info'] = self.get_sdxliff_info(filepath)
 
             return info
@@ -73,6 +74,7 @@ class FileService:
         icons = {
             '.sdltm': '🗄️',
             '.sdxliff': '📄',
+            '.sdlxliff': '📄',
             '.xlsx': '📊',
             '.xls': '📊',
             '.tmx': '🔄',

--- a/tests/test_file_service.py
+++ b/tests/test_file_service.py
@@ -12,6 +12,10 @@ def test_is_supported():
     assert service.is_supported(Path(xml_tmp.name))
     tbx_tmp = tempfile.NamedTemporaryFile(suffix=".tbx")
     assert service.is_supported(Path(tbx_tmp.name))
+    sdx_tmp = tempfile.NamedTemporaryFile(suffix=".sdxliff")
+    assert service.is_supported(Path(sdx_tmp.name))
+    sdlx_tmp = tempfile.NamedTemporaryFile(suffix=".sdlxliff")
+    assert service.is_supported(Path(sdlx_tmp.name))
 
 
 def test_get_format_name_and_icon():
@@ -20,6 +24,10 @@ def test_get_format_name_and_icon():
     path = Path(tmp.name)
     assert service.get_format_name(path) == "Excel Workbook"
     assert service.get_format_icon(path) == "📊"
+    sdlx = tempfile.NamedTemporaryFile(suffix=".sdlxliff")
+    spath = Path(sdlx.name)
+    assert service.get_format_name(spath) == "SDXLIFF File"
+    assert service.get_format_icon(spath) == "📄"
     unknown = Path(tmp.name + ".unknown")
     assert service.get_format_name(unknown) == "Unknown Format"
     assert service.get_format_icon(unknown) == "📄"
@@ -31,9 +39,11 @@ def test_detect_files_format_mixed(tmp_path):
     file1.write_text("test")
     file2 = tmp_path / "b.xlsx"
     file2.write_text("test")
-    name, valid = service.detect_files_format([str(file1), str(file2)])
+    file3 = tmp_path / "c.sdlxliff"
+    file3.write_text("test")
+    name, valid = service.detect_files_format([str(file1), str(file2), str(file3)])
     assert "Смешанные форматы" in name
-    assert set(valid) == {str(file1), str(file2)}
+    assert set(valid) == {str(file1), str(file2), str(file3)}
 
 
 def test_normalize_language():


### PR DESCRIPTION
## Summary
- recognize `.sdlxliff` as a supported file type
- display SDLXLIFF in drop area UI and file dialogs
- update tests for the new extension

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ae8ffa874832c946eb2e19db2f57f