### PR TITLE
Implement SDXLIFF split/merge UI

### DIFF
--- a/gui/dialogs/__init__.py
+++ b/gui/dialogs/__init__.py
@@ -1,9 +1,11 @@
 from .excel_config_dialog import ExcelConfigDialog
 from .language_dialog import LanguageDialog
 from .termbase_config_dialog import TermbaseConfigDialog
+from .sdxliff_config_dialog import SdxliffConfigDialog
 
 __all__ = [
     "ExcelConfigDialog",
     "LanguageDialog",
     "TermbaseConfigDialog",
+    "SdxliffConfigDialog",
 ]

--- a/gui/dialogs/sdxliff_config_dialog.py
+++ b/gui/dialogs/sdxliff_config_dialog.py
@@ -1,0 +1,57 @@
+from pathlib import Path
+from typing import List, Tuple
+from PySide6.QtWidgets import (
+    QDialog, QVBoxLayout, QHBoxLayout, QSpinBox, QLabel, QPushButton,
+    QLineEdit, QFormLayout
+)
+
+
+class SdxliffConfigDialog(QDialog):
+    """Simple dialog to configure splitting or merging SDXLIFF files."""
+
+    def __init__(self, filepaths: List[Path], parent=None):
+        super().__init__(parent)
+        self.filepaths = filepaths
+        self.action: str | None = None
+        self.parts: int = 2
+        self.output: Path | None = None
+        self._setup_ui()
+
+    def _setup_ui(self):
+        layout = QVBoxLayout(self)
+        if len(self.filepaths) == 1:
+            self.setWindowTitle("Разделить SDXLIFF")
+            form = QHBoxLayout()
+            form.addWidget(QLabel("Части:"))
+            self.parts_spin = QSpinBox()
+            self.parts_spin.setRange(2, 100)
+            form.addWidget(self.parts_spin)
+            layout.addLayout(form)
+            btn = QPushButton("Разделить")
+            btn.clicked.connect(self._on_split)
+            layout.addWidget(btn)
+        else:
+            self.setWindowTitle("Объединить SDXLIFF")
+            form = QFormLayout()
+            self.out_edit = QLineEdit(str(self.filepaths[0].parent / "merged.sdxliff"))
+            form.addRow("Выходной файл:", self.out_edit)
+            layout.addLayout(form)
+            btn = QPushButton("Объединить")
+            btn.clicked.connect(self._on_merge)
+            layout.addWidget(btn)
+        cancel = QPushButton("Отмена")
+        cancel.clicked.connect(self.reject)
+        layout.addWidget(cancel)
+
+    def _on_split(self):
+        self.action = "split"
+        self.parts = self.parts_spin.value()
+        self.accept()
+
+    def _on_merge(self):
+        self.action = "merge"
+        self.output = Path(self.out_edit.text())
+        self.accept()
+
+    def get_result(self) -> Tuple[str, int | Path]:
+        return self.action, (self.parts if self.action == "split" else self.output)

--- a/gui/widgets/__init__.py
+++ b/gui/widgets/__init__.py
@@ -1,0 +1,12 @@
+from .drop_area import SmartDropArea
+from .sdxliff_drop_area import SdxliffDropArea
+from .file_list import FileListWidget
+from .progress_widget import ProgressWidget
+
+__all__ = [
+    "SmartDropArea",
+    "SdxliffDropArea",
+    "FileListWidget",
+    "ProgressWidget",
+]
+

--- a/gui/widgets/sdxliff_drop_area.py
+++ b/gui/widgets/sdxliff_drop_area.py
@@ -1,0 +1,24 @@
+from .drop_area import SmartDropArea
+
+
+class SdxliffDropArea(SmartDropArea):
+    """Drop area that accepts only SDXLIFF files."""
+
+    def __init__(self):
+        super().__init__()
+        self.main_label.setText("Перетащите SDXLIFF файлы")
+        self.formats_label.setText("SDXLIFF")
+
+    def open_file_dialog(self):
+        from PySide6.QtWidgets import QFileDialog
+        files, _ = QFileDialog.getOpenFileNames(
+            self,
+            "Выберите SDXLIFF файлы",
+            "",
+            "SDXLIFF (*.sdxliff *.sdlxliff)"
+        )
+        if files:
+            self.files_dropped.emit(files)
+            self.format_label.setText(f"✅ Выбрано файлов: {len(files)}")
+            from PySide6.QtCore import QTimer
+            QTimer.singleShot(2000, self.reset_style)

--- a/gui/windows/main_window.py
+++ b/gui/windows/main_window.py
@@ -173,6 +173,11 @@ class MainWindow(QMainWindow):
         self.add_excel_btn.clicked.connect(self.open_excel_dialog)
         file_buttons.addWidget(self.add_excel_btn)
 
+        # Кнопка для работы с SDXLIFF split/merge
+        self.sdxliff_btn = QPushButton("🪄 Split/Merge SDXLIFF")
+        self.sdxliff_btn.clicked.connect(self.open_sdxliff_window)
+        file_buttons.addWidget(self.sdxliff_btn)
+
         self.clear_files_btn = QPushButton("Очистить")
         self.clear_files_btn.clicked.connect(self.clear_files)
         file_buttons.addWidget(self.clear_files_btn)
@@ -411,6 +416,13 @@ class MainWindow(QMainWindow):
         if files:
             for excel_file in files:
                 self.handle_excel_file(Path(excel_file))
+
+    def open_sdxliff_window(self):
+        """Открывает окно split/merge SDXLIFF"""
+        from gui.windows.sdxliff_split_window import SdxliffSplitWindow
+        if not hasattr(self, "_sdxliff_window") or self._sdxliff_window is None:
+            self._sdxliff_window = SdxliffSplitWindow(self.controller, self)
+        self._sdxliff_window.show()
 
     def clear_files(self):
         """Очищает список файлов"""

--- a/gui/windows/sdxliff_split_window.py
+++ b/gui/windows/sdxliff_split_window.py
@@ -1,13 +1,44 @@
 from pathlib import Path
-from PySide6.QtWidgets import QWidget
+from typing import List
+
+from PySide6.QtWidgets import (
+    QWidget, QVBoxLayout, QMessageBox
+)
+
 from gui.ui_constants import HEADER_FRAME_STYLE
+from gui.widgets.sdxliff_drop_area import SdxliffDropArea
+from gui.dialogs.sdxliff_config_dialog import SdxliffConfigDialog
 
 
 class SdxliffSplitWindow(QWidget):
-    def __init__(self, parent=None):
+    """Window providing drag&drop for SDXLIFF split/merge."""
+
+    def __init__(self, controller, parent=None):
         super().__init__(parent)
+        self.controller = controller
         self.setWindowTitle("SDXLIFF Split & Merge")
         self.setStyleSheet(HEADER_FRAME_STYLE)
-        # Placeholder GUI implementation
-        self.resize(400, 300)
-        # Real GUI is not implemented in tests
+        self.resize(400, 200)
+        layout = QVBoxLayout(self)
+        self.drop_area = SdxliffDropArea()
+        layout.addWidget(self.drop_area)
+        self.drop_area.files_dropped.connect(self.handle_files)
+
+    def handle_files(self, files: List[str]):
+        paths = [Path(f) for f in files if Path(f).suffix.lower() in {'.sdxliff', '.sdlxliff'}]
+        if not paths:
+            return
+        dialog = SdxliffConfigDialog(paths, self)
+        from PySide6.QtWidgets import QDialog
+        if dialog.exec() == QDialog.Accepted:
+            action, value = dialog.get_result()
+            try:
+                if action == 'split':
+                    out_paths = self.controller.split_sdxliff_file(paths[0], parts=value)
+                    QMessageBox.information(self, 'Готово', f'Создано файлов: {len(out_paths)}')
+                else:
+                    output = self.controller.merge_sdxliff_parts(paths, value)
+                    QMessageBox.information(self, 'Готово', f'Файл создан: {output.name}')
+            except Exception as e:
+                QMessageBox.critical(self, 'Ошибка', str(e))
+


### PR DESCRIPTION
## Summary
- create `SdxliffConfigDialog` for configuring split/merge
- add `SdxliffDropArea` widget
- implement `SdxliffSplitWindow` with drag & drop
- expose new widgets/dialogs via package `__init__`
- update main window with a new **Split/Merge SDXLIFF** button

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686af05b07b4832c8c40e293222e16a7