### PR TITLE
Improve SDXLIFF split/merge workflow

### DIFF
--- a/controller.py
+++ b/controller.py
@@ -40,24 +40,26 @@ class MainController:
             # Получаем информацию о файле
             file_info = self.file_service.get_file_info(filepath)
             languages = None
-            if filepath.suffix.lower() == '.sdltm':
+            if filepath.suffix.lower() == ".sdltm":
                 languages = self.file_service.auto_detect_languages(filepath)
                 if languages:
                     self.file_languages[filepath] = languages
 
             # Добавляем только поддерживаемые файлы
-            if file_info['is_supported']:
+            if file_info["is_supported"]:
                 self.files.append(filepath)
                 new_files.append(filepath)
-                files_info.append({
-                    'path': filepath,
-                    'name': file_info['name'],
-                    'size_mb': file_info['size_mb'],
-                    'format': file_info['format'],
-                    'format_icon': file_info['format_icon'],
-                    'extra_info': file_info['extra_info'],
-                    'languages': languages
-                })
+                files_info.append(
+                    {
+                        "path": filepath,
+                        "name": file_info["name"],
+                        "size_mb": file_info["size_mb"],
+                        "format": file_info["format"],
+                        "format_icon": file_info["format_icon"],
+                        "extra_info": file_info["extra_info"],
+                        "languages": languages,
+                    }
+                )
 
         # Автоопределение языков из первого SDLTM файла
         if new_files:
@@ -94,28 +96,28 @@ class MainController:
         """Возвращает автоопределенные языки"""
         return self.auto_detected_languages
 
-    def prepare_conversion_options(self, gui_options: Dict) -> 'ConversionOptions':
+    def prepare_conversion_options(self, gui_options: Dict) -> "ConversionOptions":
         """
         Создает опции конвертации из данных GUI
         """
         from core.base import ConversionOptions
 
         # Используем языки из GUI или автоопределенные
-        src_lang = gui_options.get('source_lang', '').strip()
-        tgt_lang = gui_options.get('target_lang', '').strip()
+        src_lang = gui_options.get("source_lang", "").strip()
+        tgt_lang = gui_options.get("target_lang", "").strip()
 
         if not src_lang and self.auto_detected_languages:
-            src_lang = self.auto_detected_languages.get('source', 'auto')
+            src_lang = self.auto_detected_languages.get("source", "auto")
         if not tgt_lang and self.auto_detected_languages:
-            tgt_lang = self.auto_detected_languages.get('target', 'auto')
+            tgt_lang = self.auto_detected_languages.get("target", "auto")
 
         return ConversionOptions(
-            export_tmx=gui_options.get('export_tmx', True),
-            export_xlsx=gui_options.get('export_xlsx', False),
-            export_json=gui_options.get('export_json', False),
-            source_lang=src_lang or 'auto',
-            target_lang=tgt_lang or 'auto',
-            batch_size=1000
+            export_tmx=gui_options.get("export_tmx", True),
+            export_xlsx=gui_options.get("export_xlsx", False),
+            export_json=gui_options.get("export_json", False),
+            source_lang=src_lang or "auto",
+            target_lang=tgt_lang or "auto",
+            batch_size=1000,
         )
 
     def get_files_for_conversion(self) -> List[Path]:
@@ -129,7 +131,7 @@ class MainController:
     def set_file_languages(self, filepath: Path, source: str, target: str):
         """Устанавливает языки для конкретного файла"""
         if filepath in self.files:
-            self.file_languages[filepath] = {'source': source, 'target': target}
+            self.file_languages[filepath] = {"source": source, "target": target}
 
     def get_file_language_mapping(self) -> Dict[Path, Dict[str, str]]:
         """Возвращает словарь языков для файлов"""
@@ -144,9 +146,9 @@ class MainController:
 
         # Проверяем, что выбран хотя бы один формат экспорта
         formats_selected = (
-                gui_options.get('export_tmx', False) or
-                gui_options.get('export_xlsx', False) or
-                gui_options.get('export_json', False)
+            gui_options.get("export_tmx", False)
+            or gui_options.get("export_xlsx", False)
+            or gui_options.get("export_json", False)
         )
 
         if not formats_selected:
@@ -160,11 +162,19 @@ class MainController:
 
     def is_excel_file(self, filepath: Path) -> bool:
         """Проверяет, является ли файл Excel"""
-        return filepath.suffix.lower() in ['.xlsx', '.xls']
+        return filepath.suffix.lower() in [".xlsx", ".xls"]
 
     def is_termbase_file(self, filepath: Path) -> bool:
         """Проверяет, является ли файл терминологической базой"""
-        return filepath.suffix.lower() in ['.xml', '.mtf', '.tbx']
+        return filepath.suffix.lower() in [".xml", ".mtf", ".tbx"]
+
+    def is_sdxliff_file(self, filepath: Path) -> bool:
+        """Возвращает True, если файл является SDXLIFF"""
+        return filepath.suffix.lower() in [".sdxliff", ".sdlxliff"]
+
+    def get_sdxliff_files(self) -> List[Path]:
+        """Возвращает список SDXLIFF файлов из добавленных"""
+        return [f for f in self.files if self.is_sdxliff_file(f)]
 
     def analyze_excel_file(self, filepath: Path):
         """Анализирует Excel файл для настройки конвертации"""
@@ -180,7 +190,9 @@ class MainController:
             # Анализируем структуру
             analysis = converter.analyze_excel_structure(filepath)
 
-            logger.info(f"Excel analysis completed: {filepath.name}, {len(analysis.sheets)} sheets")
+            logger.info(
+                f"Excel analysis completed: {filepath.name}, {len(analysis.sheets)} sheets"
+            )
             return analysis
 
         except Exception as e:
@@ -211,11 +223,12 @@ class MainController:
             logger.error(f"Error in Excel config dialog for {filepath}: {e}")
             # Показываем ошибку пользователю
             from PySide6.QtWidgets import QMessageBox
+
             QMessageBox.critical(
                 parent_widget,
                 "Ошибка анализа Excel",
                 f"Не удалось проанализировать Excel файл:\n\n{e}\n\n"
-                f"Убедитесь, что файл не поврежден и содержит данные."
+                f"Убедитесь, что файл не поврежден и содержит данные.",
             )
             return None
 
@@ -223,12 +236,15 @@ class MainController:
         """Диалог настройки конвертации терминологической базы"""
         try:
             from utils.term_base import extract_tb_info
+
             info = extract_tb_info(filepath)
 
             from gui.dialogs.termbase_config_dialog import TermbaseConfigDialog
             from PySide6.QtWidgets import QDialog
 
-            dialog = TermbaseConfigDialog(filepath, info.get("languages", []), parent_widget)
+            dialog = TermbaseConfigDialog(
+                filepath, info.get("languages", []), parent_widget
+            )
 
             if dialog.exec() == QDialog.Accepted:
                 return dialog.get_settings()
@@ -236,10 +252,11 @@ class MainController:
         except Exception as e:
             logger.error(f"Error in termbase config dialog for {filepath}: {e}")
             from PySide6.QtWidgets import QMessageBox
+
             QMessageBox.critical(
                 parent_widget,
                 "Ошибка анализа Termbase",
-                f"Не удалось прочитать файл:\n\n{e}"
+                f"Не удалось прочитать файл:\n\n{e}",
             )
             return None
 
@@ -251,8 +268,10 @@ class MainController:
             converter = ExcelConverter()
             result = converter.convert_excel_to_tmx(filepath, settings, options)
 
-            logger.info(f"Excel conversion result: success={result.success}, "
-                        f"output_files={len(result.output_files)}")
+            logger.info(
+                f"Excel conversion result: success={result.success}, "
+                f"output_files={len(result.output_files)}"
+            )
             return result
 
         except Exception as e:
@@ -271,7 +290,7 @@ class MainController:
             logger.error(f"Error converting termbase {filepath}: {e}")
             raise
 
-    def prepare_excel_conversion_options(self, settings) -> 'ConversionOptions':
+    def prepare_excel_conversion_options(self, settings) -> "ConversionOptions":
         """Создает опции конвертации для Excel"""
         from core.base import ConversionOptions
 
@@ -281,10 +300,10 @@ class MainController:
             export_json=False,
             source_lang=settings.source_language,
             target_lang=settings.target_language,
-            batch_size=1000
+            batch_size=1000,
         )
 
-    def prepare_termbase_conversion_options(self, settings) -> 'ConversionOptions':
+    def prepare_termbase_conversion_options(self, settings) -> "ConversionOptions":
         """Создает опции конвертации для терминологической базы"""
         from core.base import ConversionOptions
 
@@ -293,7 +312,7 @@ class MainController:
             export_xlsx=settings.export_xlsx,
             export_json=False,
             source_lang=settings.source_language,
-            target_lang='',
+            target_lang="",
             batch_size=1000,
         )
 
@@ -322,13 +341,18 @@ class MainController:
 
                 # Проверяем наличие текстовых колонок
                 from core.base import ColumnType
+
                 text_columns = [
-                    col for col in settings.column_mappings[sheet_name].values()
+                    col
+                    for col in settings.column_mappings[sheet_name].values()
                     if col.final_type == ColumnType.TEXT
                 ]
 
                 if len(text_columns) < 2:
-                    return False, f"Лист '{sheet_name}': недостаточно текстовых колонок (нужно минимум 2)"
+                    return (
+                        False,
+                        f"Лист '{sheet_name}': недостаточно текстовых колонок (нужно минимум 2)",
+                    )
 
             return True, "OK"
 
@@ -362,28 +386,28 @@ class MainController:
             sheets_info = f"{len(analysis.sheets)} листов"
 
             return {
-                'path': filepath,
-                'name': filepath.name,
-                'size_mb': filepath.stat().st_size / (1024 * 1024),
-                'format': 'Excel Workbook',
-                'format_icon': '📊',
-                'extra_info': f"{sheets_info}, ~{total_segments} сегментов",
-                'is_supported': True,
-                'is_excel': True,
-                'analysis': analysis
+                "path": filepath,
+                "name": filepath.name,
+                "size_mb": filepath.stat().st_size / (1024 * 1024),
+                "format": "Excel Workbook",
+                "format_icon": "📊",
+                "extra_info": f"{sheets_info}, ~{total_segments} сегментов",
+                "is_supported": True,
+                "is_excel": True,
+                "analysis": analysis,
             }
 
         except Exception as e:
             logger.error(f"Error getting Excel file info: {e}")
             return {
-                'path': filepath,
-                'name': filepath.name,
-                'size_mb': filepath.stat().st_size / (1024 * 1024),
-                'format': 'Excel Workbook (ошибка)',
-                'format_icon': '⚠️',
-                'extra_info': f"Ошибка анализа: {e}",
-                'is_supported': False,
-                'is_excel': True
+                "path": filepath,
+                "name": filepath.name,
+                "size_mb": filepath.stat().st_size / (1024 * 1024),
+                "format": "Excel Workbook (ошибка)",
+                "format_icon": "⚠️",
+                "extra_info": f"Ошибка анализа: {e}",
+                "is_supported": False,
+                "is_excel": True,
             }
 
     # ===========================================
@@ -397,12 +421,14 @@ class MainController:
 
         # Ищем первый SDLTM файл
         for filepath in new_files:
-            if filepath.suffix.lower() == '.sdltm':
+            if filepath.suffix.lower() == ".sdltm":
                 languages = self.file_service.auto_detect_languages(filepath)
                 if languages:
                     self.auto_detected_languages = languages
                     self.auto_language_source = filepath
-                    logger.info(f"Auto-detected languages from {filepath.name}: {languages}")
+                    logger.info(
+                        f"Auto-detected languages from {filepath.name}: {languages}"
+                    )
                     break
             elif self.is_excel_file(filepath):
                 # Для Excel файлов тоже можем попробовать определить языки
@@ -410,11 +436,13 @@ class MainController:
                     analysis = self.analyze_excel_file(filepath)
                     if analysis.detected_source_lang and analysis.detected_target_lang:
                         self.auto_detected_languages = {
-                            'source': analysis.detected_source_lang,
-                            'target': analysis.detected_target_lang
+                            "source": analysis.detected_source_lang,
+                            "target": analysis.detected_target_lang,
                         }
                         self.auto_language_source = filepath
-                        logger.info(f"Auto-detected languages from Excel: {self.auto_detected_languages}")
+                        logger.info(
+                            f"Auto-detected languages from Excel: {self.auto_detected_languages}"
+                        )
                         break
                 except Exception:
                     continue  # Игнорируем ошибки автоопределения для Excel
@@ -425,6 +453,7 @@ class MainController:
 
     def analyze_sdxliff_file(self, filepath: Path) -> dict:
         from services.split_service import SplitService
+
         service = SplitService()
         return service.analyze(filepath)
 
@@ -437,6 +466,7 @@ class MainController:
         output_dir: Path | None = None,
     ) -> list[Path]:
         from services.split_service import SplitService
+
         service = SplitService()
         return service.split(
             filepath,
@@ -447,5 +477,6 @@ class MainController:
 
     def merge_sdxliff_parts(self, part_paths: List[Path], output_path: Path) -> Path:
         from services.split_service import SplitService
+
         service = SplitService()
         return service.merge(part_paths, output_path)

--- a/gui/windows/main_window.py
+++ b/gui/windows/main_window.py
@@ -1,9 +1,19 @@
 # gui/windows/main_window.py - БЕЗ МИНИМАЛЬНЫХ РАЗМЕРОВ
 
 from PySide6.QtWidgets import (
-    QMainWindow, QWidget, QVBoxLayout, QHBoxLayout, QPushButton,
-    QLabel, QTextEdit, QFileDialog, QMessageBox,
-    QGroupBox, QCheckBox, QSplitter, QFrame
+    QMainWindow,
+    QWidget,
+    QVBoxLayout,
+    QHBoxLayout,
+    QPushButton,
+    QLabel,
+    QTextEdit,
+    QFileDialog,
+    QMessageBox,
+    QGroupBox,
+    QCheckBox,
+    QSplitter,
+    QFrame,
 )
 from PySide6.QtCore import Qt
 from PySide6.QtGui import QFont
@@ -30,8 +40,10 @@ class MainWindow(QMainWindow):
 
         # Создаем контроллер
         from controller import MainController
+
         self.controller = MainController()
         from services import ConversionManager
+
         self.manager = ConversionManager()
 
         self.setup_window()
@@ -77,20 +89,28 @@ class MainWindow(QMainWindow):
                 self.move(available_geometry.center() - window_geometry.center())
 
                 # Если окно больше доступной области, уменьшаем его
-                if (window_geometry.width() > available_geometry.width() or
-                        window_geometry.height() > available_geometry.height()):
-                    new_width = min(window_geometry.width(), available_geometry.width() - 20)
-                    new_height = min(window_geometry.height(), available_geometry.height() - 20)
+                if (
+                    window_geometry.width() > available_geometry.width()
+                    or window_geometry.height() > available_geometry.height()
+                ):
+                    new_width = min(
+                        window_geometry.width(), available_geometry.width() - 20
+                    )
+                    new_height = min(
+                        window_geometry.height(), available_geometry.height() - 20
+                    )
                     self.resize(new_width, new_height)
                     self.move(available_geometry.center() - self.rect().center())
 
     def changeEvent(self, event):
         """Обработчик изменения состояния окна"""
         from PySide6.QtCore import QEvent
+
         if event.type() == QEvent.WindowStateChange:
             if self.windowState() & Qt.WindowMaximized:
                 # При максимизации используем доступную область экрана
                 from PySide6.QtWidgets import QApplication
+
                 screen = QApplication.primaryScreen()
                 if screen:
                     # Используем availableGeometry вместо geometry
@@ -154,6 +174,7 @@ class MainWindow(QMainWindow):
 
         # Область для перетаскивания файлов
         from gui.widgets.drop_area import SmartDropArea
+
         self.drop_area = SmartDropArea()
         # Подключаем к контроллеру
         self.drop_area.files_dropped.connect(self.on_files_dropped)
@@ -175,6 +196,7 @@ class MainWindow(QMainWindow):
 
         # Кнопка для работы с SDXLIFF split/merge
         self.sdxliff_btn = QPushButton("🪄 Split/Merge SDXLIFF")
+        self.sdxliff_btn.setEnabled(False)
         self.sdxliff_btn.clicked.connect(self.open_sdxliff_window)
         file_buttons.addWidget(self.sdxliff_btn)
 
@@ -187,6 +209,7 @@ class MainWindow(QMainWindow):
 
         # Список файлов
         from gui.widgets.file_list import FileListWidget
+
         self.file_list = FileListWidget()
         self.file_list.file_remove_requested.connect(self.on_file_remove_requested)
         self.file_list.clear_all_btn.clicked.connect(self.clear_files)
@@ -223,6 +246,7 @@ class MainWindow(QMainWindow):
 
         # Виджет прогресса
         from gui.widgets.progress_widget import ProgressWidget
+
         self.progress_widget = ProgressWidget()
         layout.addWidget(self.progress_widget)
 
@@ -291,9 +315,13 @@ class MainWindow(QMainWindow):
         self.manager.file_completed.connect(self.on_file_completed)
         self.manager.batch_completed.connect(self.on_batch_completed)
         self.manager.error_occurred.connect(self.on_conversion_error)
-        self.manager.excel_conversion_finished.connect(self.on_excel_conversion_finished)
+        self.manager.excel_conversion_finished.connect(
+            self.on_excel_conversion_finished
+        )
         self.manager.excel_conversion_error.connect(self.on_excel_conversion_error)
-        self.manager.tb_progress.connect(lambda p: self.progress_widget.update_progress(p, "TB", 1, 1))
+        self.manager.tb_progress.connect(
+            lambda p: self.progress_widget.update_progress(p, "TB", 1, 1)
+        )
         self.manager.tb_log.connect(self.log_message)
         self.manager.tb_finished.connect(self.on_tb_conversion_finished)
         self.manager.tb_error.connect(self.on_tb_conversion_error)
@@ -321,7 +349,7 @@ class MainWindow(QMainWindow):
 
         if filename:
             try:
-                with open(filename, 'w', encoding='utf-8') as f:
+                with open(filename, "w", encoding="utf-8") as f:
                     f.write(self.log_text.toPlainText())
                 self.log_message(f"Логи сохранены в: {filename}")
             except Exception as e:
@@ -330,6 +358,7 @@ class MainWindow(QMainWindow):
     def log_message(self, message: str):
         """Добавляет сообщение в лог"""
         from datetime import datetime
+
         timestamp = datetime.now().strftime("%H:%M:%S")
         formatted_message = f"[{timestamp}] {message}"
         self.log_text.append(formatted_message)
@@ -342,7 +371,9 @@ class MainWindow(QMainWindow):
         # Ограничиваем количество строк в логе
         if self.log_text.document().lineCount() > 1000:
             cursor.movePosition(cursor.MoveOperation.Start)
-            cursor.movePosition(cursor.MoveOperation.Down, cursor.MoveMode.KeepAnchor, 100)
+            cursor.movePosition(
+                cursor.MoveOperation.Down, cursor.MoveMode.KeepAnchor, 100
+            )
             cursor.removeSelectedText()
 
     # ===========================================
@@ -398,7 +429,7 @@ class MainWindow(QMainWindow):
             self,
             "Выберите файлы для конвертации",
             "",
-            "Все поддерживаемые (*.sdltm *.sdxliff *.sdlxliff *.xlsx *.xls *.tmx *.xml *.mtf *.tbx);;SDLTM (*.sdltm);;SDLXLIFF (*.sdxliff *.sdlxliff);;Excel (*.xlsx *.xls);;TMX (*.tmx);;XML/Termbase (*.xml *.mtf *.tbx)"
+            "Все поддерживаемые (*.sdltm *.sdxliff *.sdlxliff *.xlsx *.xls *.tmx *.xml *.mtf *.tbx);;SDLTM (*.sdltm);;SDLXLIFF (*.sdxliff *.sdlxliff);;Excel (*.xlsx *.xls);;TMX (*.tmx);;XML/Termbase (*.xml *.mtf *.tbx)",
         )
 
         if files:
@@ -410,7 +441,7 @@ class MainWindow(QMainWindow):
             self,
             "Выберите Excel файлы для конвертации",
             "",
-            "Excel файлы (*.xlsx *.xls);;XLSX (*.xlsx);;XLS (*.xls)"
+            "Excel файлы (*.xlsx *.xls);;XLSX (*.xlsx);;XLS (*.xls)",
         )
 
         if files:
@@ -420,8 +451,17 @@ class MainWindow(QMainWindow):
     def open_sdxliff_window(self):
         """Открывает окно split/merge SDXLIFF"""
         from gui.windows.sdxliff_split_window import SdxliffSplitWindow
+
+        files = self.controller.get_sdxliff_files()
+        if not files:
+            QMessageBox.information(
+                self, "Нет файлов", "Нет SDXLIFF файлов для обработки"
+            )
+            return
         if not hasattr(self, "_sdxliff_window") or self._sdxliff_window is None:
-            self._sdxliff_window = SdxliffSplitWindow(self.controller, self)
+            self._sdxliff_window = SdxliffSplitWindow(self.controller, files, self)
+        else:
+            self._sdxliff_window.set_files(files)
         self._sdxliff_window.show()
 
     def clear_files(self):
@@ -459,14 +499,14 @@ class MainWindow(QMainWindow):
             QMessageBox.critical(
                 self,
                 "Ошибка Excel",
-                f"Не удалось обработать Excel файл:\n\n{filepath.name}\n\n{e}"
+                f"Не удалось обработать Excel файл:\n\n{filepath.name}\n\n{e}",
             )
 
     def edit_file_languages(self, filepath: Path):
         """Открывает диалог ручной настройки языков для файла"""
         langs = self.controller.get_file_languages(filepath) or {}
-        src = langs.get('source', '')
-        tgt = langs.get('target', '')
+        src = langs.get("source", "")
+        tgt = langs.get("target", "")
         from gui.dialogs import LanguageDialog
         from PySide6.QtWidgets import QDialog
 
@@ -475,13 +515,17 @@ class MainWindow(QMainWindow):
             src_lang, tgt_lang = dialog.get_languages()
             if src_lang or tgt_lang:
                 self.controller.set_file_languages(filepath, src_lang, tgt_lang)
-                self.file_list.set_file_languages(filepath, {'source': src_lang, 'target': tgt_lang})
+                self.file_list.set_file_languages(
+                    filepath, {"source": src_lang, "target": tgt_lang}
+                )
 
     def start_excel_conversion(self, filepath: Path, settings):
         """Запускает конвертацию Excel файла"""
         try:
             # Валидируем настройки
-            is_valid, error_msg = self.controller.validate_excel_conversion_settings(settings)
+            is_valid, error_msg = self.controller.validate_excel_conversion_settings(
+                settings
+            )
             if not is_valid:
                 QMessageBox.warning(self, "Ошибка настроек", error_msg)
                 return
@@ -490,8 +534,10 @@ class MainWindow(QMainWindow):
             options = self.controller.prepare_excel_conversion_options(settings)
 
             # Добавляем колбэки прогресса
-            options.progress_callback = lambda progress, message: self.progress_widget.update_progress(
-                progress, f"Excel: {message}", 1, 1
+            options.progress_callback = (
+                lambda progress, message: self.progress_widget.update_progress(
+                    progress, f"Excel: {message}", 1, 1
+                )
             )
             options.should_stop_callback = lambda: not self.is_converting
 
@@ -508,7 +554,9 @@ class MainWindow(QMainWindow):
             self.progress_widget.reset()
             self.log_message(f"🚀 Начата конвертация Excel: {filepath.name}")
             self.log_message(f"   📊 Листов: {len(settings.selected_sheets)}")
-            self.log_message(f"   🌐 Языки: {settings.source_language} → {settings.target_language}")
+            self.log_message(
+                f"   🌐 Языки: {settings.source_language} → {settings.target_language}"
+            )
 
         except Exception as e:
             error_msg = f"Ошибка запуска Excel конвертации: {e}"
@@ -518,7 +566,7 @@ class MainWindow(QMainWindow):
             QMessageBox.critical(
                 self,
                 "Ошибка запуска",
-                f"Не удалось запустить конвертацию Excel:\n\n{e}"
+                f"Не удалось запустить конвертацию Excel:\n\n{e}",
             )
 
     def handle_termbase_file(self, filepath: Path):
@@ -539,20 +587,26 @@ class MainWindow(QMainWindow):
             QMessageBox.critical(
                 self,
                 "Ошибка TB",
-                f"Не удалось обработать файл:\n\n{filepath.name}\n\n{e}"
+                f"Не удалось обработать файл:\n\n{filepath.name}\n\n{e}",
             )
 
     def start_termbase_conversion(self, filepath: Path, settings):
         """Запускает конвертацию терминологической базы"""
         try:
-            is_valid, error_msg = self.controller.validate_termbase_conversion_settings(settings)
+            is_valid, error_msg = self.controller.validate_termbase_conversion_settings(
+                settings
+            )
             if not is_valid:
                 QMessageBox.warning(self, "Ошибка настроек", error_msg)
                 return
 
             options = self.controller.prepare_termbase_conversion_options(settings)
 
-            options.progress_callback = lambda p, msg: self.progress_widget.update_progress(p, f"TB: {msg}", 1, 1)
+            options.progress_callback = (
+                lambda p, msg: self.progress_widget.update_progress(
+                    p, f"TB: {msg}", 1, 1
+                )
+            )
             options.should_stop_callback = lambda: not self.is_converting
 
             self.manager.start_termbase(filepath, options)
@@ -570,9 +624,7 @@ class MainWindow(QMainWindow):
             self.log_message(f"💥 {error_msg}")
             logger.exception(error_msg)
             QMessageBox.critical(
-                self,
-                "Ошибка запуска",
-                f"Не удалось запустить конвертацию TB:\n\n{e}"
+                self, "Ошибка запуска", f"Не удалось запустить конвертацию TB:\n\n{e}"
             )
 
     def on_excel_conversion_finished(self, result):
@@ -590,23 +642,30 @@ class MainWindow(QMainWindow):
                 # Успешная конвертация
                 stats = result.stats
 
-                self.progress_widget.set_completion_status(True, "Excel конвертация завершена!")
+                self.progress_widget.set_completion_status(
+                    True, "Excel конвертация завершена!"
+                )
 
                 self.log_message(
                     f"✅ Excel конвертация завершена за {stats.get('conversion_time', 0):.1f}с! "
-                    f"Экспортировано: {stats.get('exported_segments', 0)} сегментов")
+                    f"Экспортировано: {stats.get('exported_segments', 0)} сегментов"
+                )
 
             else:
                 # Ошибка конвертации
-                self.progress_widget.set_completion_status(False, "Ошибка Excel конвертации")
+                self.progress_widget.set_completion_status(
+                    False, "Ошибка Excel конвертации"
+                )
 
-                error_msg = '; '.join(result.errors) if result.errors else "Неизвестная ошибка"
+                error_msg = (
+                    "; ".join(result.errors) if result.errors else "Неизвестная ошибка"
+                )
                 self.log_message(f"❌ Ошибка Excel конвертации: {error_msg}")
 
                 QMessageBox.warning(
                     self,
                     "Ошибка конвертации",
-                    f"Не удалось конвертировать Excel файл:\n\n{error_msg}"
+                    f"Не удалось конвертировать Excel файл:\n\n{error_msg}",
                 )
 
         except Exception as e:
@@ -629,7 +688,7 @@ class MainWindow(QMainWindow):
             QMessageBox.critical(
                 self,
                 "Критическая ошибка",
-                f"Произошла критическая ошибка при конвертации Excel:\n\n{error_msg}"
+                f"Произошла критическая ошибка при конвертации Excel:\n\n{error_msg}",
             )
 
         except Exception as e:
@@ -644,7 +703,9 @@ class MainWindow(QMainWindow):
         self.add_excel_btn.setEnabled(True)
 
         if success:
-            self.progress_widget.set_completion_status(True, "TB конвертация завершена!")
+            self.progress_widget.set_completion_status(
+                True, "TB конвертация завершена!"
+            )
             self.log_message(f"✅ {message}")
         else:
             self.progress_widget.set_completion_status(False, "Ошибка TB конвертации")
@@ -663,9 +724,9 @@ class MainWindow(QMainWindow):
         """Запускает конвертацию обычных файлов"""
         # Собираем опции из GUI
         gui_options = {
-            'export_tmx': self.tmx_cb.isChecked(),
-            'export_xlsx': self.xlsx_cb.isChecked(),
-            'export_json': self.json_cb.isChecked()
+            "export_tmx": self.tmx_cb.isChecked(),
+            "export_xlsx": self.xlsx_cb.isChecked(),
+            "export_json": self.json_cb.isChecked(),
         }
 
         # Валидируем через контроллер
@@ -690,7 +751,9 @@ class MainWindow(QMainWindow):
         self.file_list.reset_all_status()
 
         # Запускаем конвертацию через worker
-        self.manager.start_batch(files, options, self.controller.get_file_language_mapping())
+        self.manager.start_batch(
+            files, options, self.controller.get_file_language_mapping()
+        )
         self.log_message(f"🚀 Начата конвертация {len(files)} файлов")
 
     def stop_conversion(self):
@@ -707,15 +770,17 @@ class MainWindow(QMainWindow):
         files_info = []
         for filepath in self.controller.get_files_for_conversion():
             file_info = self.controller.file_service.get_file_info(filepath)
-            files_info.append({
-                'path': filepath,
-                'name': file_info['name'],
-                'size_mb': file_info['size_mb'],
-                'format': file_info['format'],
-                'format_icon': file_info['format_icon'],
-                'extra_info': file_info['extra_info'],
-                'languages': self.controller.get_file_languages(filepath)
-            })
+            files_info.append(
+                {
+                    "path": filepath,
+                    "name": file_info["name"],
+                    "size_mb": file_info["size_mb"],
+                    "format": file_info["format"],
+                    "format_icon": file_info["format_icon"],
+                    "extra_info": file_info["extra_info"],
+                    "languages": self.controller.get_file_languages(filepath),
+                }
+            )
 
         self.file_list.update_files(files_info)
 
@@ -734,16 +799,27 @@ class MainWindow(QMainWindow):
             self.auto_langs_label.setText("Будут определены из файла")
             self.auto_langs_label.setStyleSheet("color: #666; font-style: italic;")
 
+    def _update_sdxliff_button_state(self):
+        """Включает кнопку Split/Merge при наличии SDXLIFF файлов"""
+        has_sdxliff = len(self.controller.get_sdxliff_files()) > 0
+        self.sdxliff_btn.setEnabled(has_sdxliff)
+
     # ===========================================
     # ОБРАБОТЧИКИ WORKER'А ДЛЯ ОБЫЧНЫХ ФАЙЛОВ
     # ===========================================
 
-    def on_progress_update(self, progress: int, message: str, current_file: int, total_files: int):
+    def on_progress_update(
+        self, progress: int, message: str, current_file: int, total_files: int
+    ):
         """Обработчик обновления прогресса"""
-        self.progress_widget.update_progress(progress, message, current_file, total_files)
+        self.progress_widget.update_progress(
+            progress, message, current_file, total_files
+        )
 
         if total_files > 0:
-            self.status_label.setText(f"Обработка файла {current_file}/{total_files}: {message}")
+            self.status_label.setText(
+                f"Обработка файла {current_file}/{total_files}: {message}"
+            )
         else:
             self.status_label.setText(message)
 
@@ -764,10 +840,14 @@ class MainWindow(QMainWindow):
         if file_item:
             if result.success:
                 stats = result.stats
-                exported_count = stats.get('exported', 0)
-                file_item.set_conversion_completed(True, f"Экспортировано: {exported_count}")
+                exported_count = stats.get("exported", 0)
+                file_item.set_conversion_completed(
+                    True, f"Экспортировано: {exported_count}"
+                )
             else:
-                error_msg = '; '.join(result.errors) if result.errors else "Неизвестная ошибка"
+                error_msg = (
+                    "; ".join(result.errors) if result.errors else "Неизвестная ошибка"
+                )
                 file_item.set_conversion_completed(False, error_msg)
 
         if result.success:
@@ -779,9 +859,12 @@ class MainWindow(QMainWindow):
             self.log_message(
                 f"   Экспортировано: {stats.get('exported', 0)} | "
                 f"Всего: {stats.get('total_in_sdltm', stats.get('total', 0))} | "
-                f"Время: {stats.get('conversion_time', 0):.1f}с")
+                f"Время: {stats.get('conversion_time', 0):.1f}с"
+            )
         else:
-            error_msg = '; '.join(result.errors) if result.errors else "Неизвестная ошибка"
+            error_msg = (
+                "; ".join(result.errors) if result.errors else "Неизвестная ошибка"
+            )
             self.log_message(f"❌ Ошибка: {filepath.name} - {error_msg}")
 
     def on_batch_completed(self, results: List):
@@ -800,9 +883,13 @@ class MainWindow(QMainWindow):
 
         # Финальный статус в progress_widget
         if successful == total:
-            self.progress_widget.set_completion_status(True, f"Все файлы успешно конвертированы!")
+            self.progress_widget.set_completion_status(
+                True, f"Все файлы успешно конвертированы!"
+            )
         else:
-            self.progress_widget.set_completion_status(False, f"Конвертировано {successful} из {total} файлов")
+            self.progress_widget.set_completion_status(
+                False, f"Конвертировано {successful} из {total} файлов"
+            )
 
         # Итоговое сообщение
         self.log_message(f"🎉 Конвертация завершена: {successful}/{total} успешно")
@@ -813,7 +900,7 @@ class MainWindow(QMainWindow):
                 self,
                 "Конвертация не удалась",
                 f"Ни один файл не был успешно конвертирован.\n"
-                f"Проверьте логи для подробностей."
+                f"Проверьте логи для подробностей.",
             )
 
     def on_conversion_error(self, error_msg: str):
@@ -838,13 +925,14 @@ class MainWindow(QMainWindow):
             self,
             "Ошибка конвертации",
             f"Произошла критическая ошибка:\n\n{error_msg}\n\n"
-            f"Проверьте логи для подробностей."
+            f"Проверьте логи для подробностей.",
         )
 
     def on_files_changed(self, file_count: int):
         """Обработчик изменения списка файлов"""
         self.start_btn.setEnabled(file_count > 0 and not self.is_converting)
         self.status_label.setText(f"Файлов в очереди: {file_count}")
+        self._update_sdxliff_button_state()
 
     def closeEvent(self, event):
         """Обработчик закрытия окна"""
@@ -855,7 +943,7 @@ class MainWindow(QMainWindow):
                 "Конвертация в процессе",
                 "Конвертация еще не завершена. Остановить и закрыть приложение?",
                 QMessageBox.Yes | QMessageBox.No,
-                QMessageBox.No
+                QMessageBox.No,
             )
 
             if reply == QMessageBox.No:
@@ -867,4 +955,3 @@ class MainWindow(QMainWindow):
         self.manager.shutdown()
         event.accept()
         logger.info("Main window closed")
-

--- a/gui/windows/sdxliff_split_window.py
+++ b/gui/windows/sdxliff_split_window.py
@@ -2,43 +2,193 @@ from pathlib import Path
 from typing import List
 
 from PySide6.QtWidgets import (
-    QWidget, QVBoxLayout, QMessageBox
+    QWidget,
+    QVBoxLayout,
+    QHBoxLayout,
+    QPushButton,
+    QRadioButton,
+    QButtonGroup,
+    QSpinBox,
+    QLabel,
+    QProgressBar,
+    QTabWidget,
+    QListWidget,
+    QListWidgetItem,
+    QFileDialog,
+    QMessageBox,
+    QTableWidget,
+    QTableWidgetItem,
 )
 
 from gui.ui_constants import HEADER_FRAME_STYLE
-from gui.widgets.sdxliff_drop_area import SdxliffDropArea
-from gui.dialogs.sdxliff_config_dialog import SdxliffConfigDialog
 
 
 class SdxliffSplitWindow(QWidget):
-    """Window providing drag&drop for SDXLIFF split/merge."""
+    """Window with tabs for splitting and merging SDXLIFF files."""
 
-    def __init__(self, controller, parent=None):
+    def __init__(self, controller, files: List[Path], parent=None):
         super().__init__(parent)
         self.controller = controller
+        self.files: List[Path] = files
         self.setWindowTitle("SDXLIFF Split & Merge")
         self.setStyleSheet(HEADER_FRAME_STYLE)
-        self.resize(400, 200)
+        self.resize(500, 300)
         layout = QVBoxLayout(self)
-        self.drop_area = SdxliffDropArea()
-        layout.addWidget(self.drop_area)
-        self.drop_area.files_dropped.connect(self.handle_files)
 
-    def handle_files(self, files: List[str]):
-        paths = [Path(f) for f in files if Path(f).suffix.lower() in {'.sdxliff', '.sdlxliff'}]
-        if not paths:
+        self.tabs = QTabWidget()
+        layout.addWidget(self.tabs)
+
+        self._create_split_tab()
+        self._create_merge_tab()
+        self._populate_merge_files()
+
+    # ------------------------------------------------------------------
+    # Split Tab
+    # ------------------------------------------------------------------
+    def _create_split_tab(self):
+        widget = QWidget()
+        tab_layout = QVBoxLayout(widget)
+
+        radio_layout = QHBoxLayout()
+        self.parts_radio = QRadioButton("по частям")
+        self.words_radio = QRadioButton("по словам")
+        self.parts_radio.setChecked(True)
+        self.radio_group = QButtonGroup(widget)
+        self.radio_group.addButton(self.parts_radio)
+        self.radio_group.addButton(self.words_radio)
+        radio_layout.addWidget(self.parts_radio)
+        radio_layout.addWidget(self.words_radio)
+        radio_layout.addStretch()
+        tab_layout.addLayout(radio_layout)
+
+        self.count_spin = QSpinBox()
+        self.count_spin.setRange(1, 9999)
+        tab_layout.addWidget(self.count_spin)
+
+        analyze_layout = QHBoxLayout()
+        self.analyze_btn = QPushButton("Анализировать")
+        self.analyze_btn.clicked.connect(self.analyze_file)
+        analyze_layout.addWidget(self.analyze_btn)
+        analyze_layout.addStretch()
+        tab_layout.addLayout(analyze_layout)
+
+        self.stats_table = QTableWidget(2, 2)
+        self.stats_table.setHorizontalHeaderLabels(["Параметр", "Значение"])
+        self.stats_table.verticalHeader().setVisible(False)
+        self.stats_table.setEditTriggers(QTableWidget.NoEditTriggers)
+        self.stats_table.setItem(0, 0, QTableWidgetItem("Сегментов"))
+        self.stats_table.setItem(1, 0, QTableWidgetItem("Слов"))
+        tab_layout.addWidget(self.stats_table)
+
+        self.split_btn = QPushButton("Разделить")
+        self.split_btn.clicked.connect(self.do_split)
+        tab_layout.addWidget(self.split_btn)
+
+        self.split_progress = QProgressBar()
+        tab_layout.addWidget(self.split_progress)
+
+        self.tabs.addTab(widget, "Разделить")
+
+    # ------------------------------------------------------------------
+    # Merge Tab
+    # ------------------------------------------------------------------
+    def _create_merge_tab(self):
+        widget = QWidget()
+        tab_layout = QVBoxLayout(widget)
+
+        self.file_list = QListWidget()
+        tab_layout.addWidget(self.file_list)
+
+        self.merge_btn = QPushButton("Объединить")
+        self.merge_btn.clicked.connect(self.do_merge)
+        tab_layout.addWidget(self.merge_btn)
+
+        self.merge_progress = QProgressBar()
+        tab_layout.addWidget(self.merge_progress)
+
+        self.tabs.addTab(widget, "Объединить")
+
+    def set_files(self, files: List[Path]):
+        self.files = files
+        self._populate_merge_files()
+
+    # ------------------------------------------------------------------
+    def analyze_file(self):
+        if not self.files:
             return
-        dialog = SdxliffConfigDialog(paths, self)
-        from PySide6.QtWidgets import QDialog
-        if dialog.exec() == QDialog.Accepted:
-            action, value = dialog.get_result()
-            try:
-                if action == 'split':
-                    out_paths = self.controller.split_sdxliff_file(paths[0], parts=value)
-                    QMessageBox.information(self, 'Готово', f'Создано файлов: {len(out_paths)}')
-                else:
-                    output = self.controller.merge_sdxliff_parts(paths, value)
-                    QMessageBox.information(self, 'Готово', f'Файл создан: {output.name}')
-            except Exception as e:
-                QMessageBox.critical(self, 'Ошибка', str(e))
+        try:
+            info = self.controller.analyze_sdxliff_file(self.files[0])
+            self.stats_table.setItem(
+                0, 1, QTableWidgetItem(str(info.get("segments", 0)))
+            )
+            self.stats_table.setItem(1, 1, QTableWidgetItem(str(info.get("words", 0))))
+        except Exception as e:
+            QMessageBox.critical(self, "Ошибка", str(e))
 
+    def do_split(self):
+        if not self.files:
+            return
+        kwargs = {}
+        if self.parts_radio.isChecked():
+            kwargs["parts"] = self.count_spin.value()
+        else:
+            kwargs["words"] = self.count_spin.value()
+        try:
+            out_paths = self.controller.split_sdxliff_file(self.files[0], **kwargs)
+            QMessageBox.information(self, "Готово", f"Создано файлов: {len(out_paths)}")
+        except Exception as e:
+            QMessageBox.critical(self, "Ошибка", str(e))
+
+    def _populate_merge_files(self):
+        self.file_list.clear()
+        valid = self._validate_parts(self.files)
+        for p in self.files:
+            item = QListWidgetItem(p.name)
+            item.setText(f"{'✅' if valid else '❌'} {p.name}")
+            self.file_list.addItem(item)
+        self.merge_btn.setEnabled(valid)
+
+    def _validate_parts(self, files: List[Path]) -> bool:
+        if not files:
+            return False
+        try:
+            from lxml import etree
+
+            metas = []
+            for f in files:
+                tree = etree.parse(str(f))
+                file_elem = tree.getroot().find(".//{*}file")
+                metas.append(
+                    (
+                        file_elem.get("original_file_id"),
+                        int(file_elem.get("part_number", "0")),
+                        int(file_elem.get("total_parts", "0")),
+                    )
+                )
+            file_id = metas[0][0]
+            total = metas[0][2]
+            numbers = {m[1] for m in metas}
+            if len(metas) != total:
+                return False
+            if numbers != set(range(1, total + 1)):
+                return False
+            for fid, _, t in metas:
+                if fid != file_id or t != total:
+                    return False
+            return True
+        except Exception:
+            return False
+
+    def do_merge(self):
+        if not self.files:
+            return
+        out_file, _ = QFileDialog.getSaveFileName(
+            self, "Выберите файл", "merged.sdxliff", "SDXLIFF (*.sdxliff)"
+        )
+        if not out_file:
+            return
+        try:
+            out = self.controller.merge_sdxliff_parts(self.files, Path(out_file))
+            QMessageBox.information(self, "Готово", f"Файл создан: {out.name}")
+        except Exception as e:
+            QMessageBox.critical(self, "Ошибка", str(e))


### PR DESCRIPTION
## Summary
- enable Split/Merge button only when SDXLIFF files are loaded
- pass loaded files to split/merge window
- redesign SDXLIFF window with two tabs for splitting and merging
- provide helper methods in controller for SDXLIFF detection

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686af4a96980832c9a80d8250a8d0506