### PR TITLE
Add characters statistic for SDXLIFF analysis

### DIFF
--- a/gui/dialogs/sdxliff_tools_dialog.py
+++ b/gui/dialogs/sdxliff_tools_dialog.py
@@ -102,12 +102,15 @@ class SdxliffToolsDialog(QDialog):
         analyze_layout.addStretch()
         tab_layout.addLayout(analyze_layout)
 
-        self.stats_table = QTableWidget(2, 2)
-        self.stats_table.setHorizontalHeaderLabels(["Параметр", "Значение"])
+        self.stats_table = QTableWidget(0, 4)
+        self.stats_table.setHorizontalHeaderLabels([
+            "Файл",
+            "Слов",
+            "Сегментов",
+            "Знаков с пробелами",
+        ])
         self.stats_table.verticalHeader().setVisible(False)
         self.stats_table.setEditTriggers(QTableWidget.NoEditTriggers)
-        self.stats_table.setItem(0, 0, QTableWidgetItem("Сегментов"))
-        self.stats_table.setItem(1, 0, QTableWidgetItem("Слов"))
         tab_layout.addWidget(self.stats_table)
 
         self.split_btn = QPushButton("Разделить")
@@ -151,10 +154,11 @@ class SdxliffToolsDialog(QDialog):
             return
         try:
             info = self.controller.analyze_sdxliff_file(self.files[0])
-            self.stats_table.setItem(
-                0, 1, QTableWidgetItem(str(info.get("segments", 0)))
-            )
-            self.stats_table.setItem(1, 1, QTableWidgetItem(str(info.get("words", 0))))
+            self.stats_table.setRowCount(1)
+            self.stats_table.setItem(0, 0, QTableWidgetItem(self.files[0].name))
+            self.stats_table.setItem(0, 1, QTableWidgetItem(str(info.get("words", 0))))
+            self.stats_table.setItem(0, 2, QTableWidgetItem(str(info.get("segments", 0))))
+            self.stats_table.setItem(0, 3, QTableWidgetItem(str(info.get("characters", 0))))
         except Exception as e:
             QMessageBox.critical(self, "Ошибка", str(e))
 
@@ -168,6 +172,13 @@ class SdxliffToolsDialog(QDialog):
             kwargs["words"] = self.count_spin.value()
         try:
             out_paths = self.controller.split_sdxliff_file(self.files[0], **kwargs)
+            self.stats_table.setRowCount(len(out_paths))
+            for row, path in enumerate(out_paths):
+                info = self.controller.analyze_sdxliff_file(path)
+                self.stats_table.setItem(row, 0, QTableWidgetItem(path.name))
+                self.stats_table.setItem(row, 1, QTableWidgetItem(str(info.get("words", 0))))
+                self.stats_table.setItem(row, 2, QTableWidgetItem(str(info.get("segments", 0))))
+                self.stats_table.setItem(row, 3, QTableWidgetItem(str(info.get("characters", 0))))
             QMessageBox.information(self, "Готово", f"Создано файлов: {len(out_paths)}")
         except Exception as e:
             QMessageBox.critical(self, "Ошибка", str(e))

--- a/gui/windows/sdxliff_split_window.py
+++ b/gui/windows/sdxliff_split_window.py
@@ -72,12 +72,15 @@ class SdxliffSplitWindow(QWidget):
         analyze_layout.addStretch()
         tab_layout.addLayout(analyze_layout)
 
-        self.stats_table = QTableWidget(2, 2)
-        self.stats_table.setHorizontalHeaderLabels(["Параметр", "Значение"])
+        self.stats_table = QTableWidget(0, 4)
+        self.stats_table.setHorizontalHeaderLabels([
+            "Файл",
+            "Слов",
+            "Сегментов",
+            "Знаков с пробелами",
+        ])
         self.stats_table.verticalHeader().setVisible(False)
         self.stats_table.setEditTriggers(QTableWidget.NoEditTriggers)
-        self.stats_table.setItem(0, 0, QTableWidgetItem("Сегментов"))
-        self.stats_table.setItem(1, 0, QTableWidgetItem("Слов"))
         tab_layout.addWidget(self.stats_table)
 
         self.split_btn = QPushButton("Разделить")
@@ -118,10 +121,11 @@ class SdxliffSplitWindow(QWidget):
             return
         try:
             info = self.controller.analyze_sdxliff_file(self.files[0])
-            self.stats_table.setItem(
-                0, 1, QTableWidgetItem(str(info.get("segments", 0)))
-            )
-            self.stats_table.setItem(1, 1, QTableWidgetItem(str(info.get("words", 0))))
+            self.stats_table.setRowCount(1)
+            self.stats_table.setItem(0, 0, QTableWidgetItem(self.files[0].name))
+            self.stats_table.setItem(0, 1, QTableWidgetItem(str(info.get("words", 0))))
+            self.stats_table.setItem(0, 2, QTableWidgetItem(str(info.get("segments", 0))))
+            self.stats_table.setItem(0, 3, QTableWidgetItem(str(info.get("characters", 0))))
         except Exception as e:
             QMessageBox.critical(self, "Ошибка", str(e))
 
@@ -135,6 +139,13 @@ class SdxliffSplitWindow(QWidget):
             kwargs["words"] = self.count_spin.value()
         try:
             out_paths = self.controller.split_sdxliff_file(self.files[0], **kwargs)
+            self.stats_table.setRowCount(len(out_paths))
+            for row, path in enumerate(out_paths):
+                info = self.controller.analyze_sdxliff_file(path)
+                self.stats_table.setItem(row, 0, QTableWidgetItem(path.name))
+                self.stats_table.setItem(row, 1, QTableWidgetItem(str(info.get("words", 0))))
+                self.stats_table.setItem(row, 2, QTableWidgetItem(str(info.get("segments", 0))))
+                self.stats_table.setItem(row, 3, QTableWidgetItem(str(info.get("characters", 0))))
             QMessageBox.information(self, "Готово", f"Создано файлов: {len(out_paths)}")
         except Exception as e:
             QMessageBox.critical(self, "Ошибка", str(e))

--- a/services/split_service.py
+++ b/services/split_service.py
@@ -18,11 +18,13 @@ class SplitService:
         tree = etree.parse(str(filepath), parser)
         units = tree.findall(".//{*}trans-unit")
         word_count = 0
+        char_count = 0
         for u in units:
             src = u.find(".//{*}source")
             text = "" if src is None else "".join(src.itertext())
             word_count += count_words(text)
-        return {"segments": len(units), "words": word_count}
+            char_count += len(text)
+        return {"segments": len(units), "words": word_count, "characters": char_count}
 
     def split(
         self,

--- a/tests/test_sdxliff_split.py
+++ b/tests/test_sdxliff_split.py
@@ -20,6 +20,7 @@ def test_split_and_merge(tmp_path: Path):
     info = service.analyze(src)
     assert info["segments"] == 2
     assert info["words"] == 3
+    assert info["characters"] == 18
 
     parts = service.split(src, parts=2)
     assert len(parts) == 2


### PR DESCRIPTION
## Summary
- track character counts in `SplitService.analyze`
- expand SDXLIFF stats tables in GUI to show file name, words, segments and characters
- update split results table after creating parts
- test character count in SDXLIFF analysis

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686afa46f3d8832ca9c9b52ac934f421