### PR TITLE
Enable SDXLIFF group-aware splitting and merging

### DIFF
--- a/core/splitters/sdxliff_merger.py
+++ b/core/splitters/sdxliff_merger.py
@@ -1,7 +1,10 @@
 from pathlib import Path
-from typing import List, Optional, Callable
+from typing import Callable, Dict, List, Optional, Tuple
 from copy import deepcopy
+from collections import defaultdict
 from lxml import etree
+
+from .sdxliff_splitter import SPLIT_NS, _is_group, _is_trans_unit
 
 
 class SdxliffMerger:
@@ -17,45 +20,109 @@ class SdxliffMerger:
     ) -> Path:
         if not part_paths:
             raise ValueError("No parts provided")
-        # parse all
-        parts = []
+
+        parsed_parts: List[Tuple[dict, etree._ElementTree]] = []
         for p in part_paths:
             tree = etree.parse(str(p))
             root = tree.getroot()
             file_elem = root.find(".//{*}file")
-            body = file_elem.find(".//{*}body")
-            units = body.findall(".//{*}trans-unit")
             meta = {
-                'file_id': file_elem.get('original_file_id'),
-                'part_number': int(file_elem.get('part_number', '0')),
-                'total_parts': int(file_elem.get('total_parts', '0')),
+                "file_id": file_elem.get("original_file_id"),
+                "part_number": int(file_elem.get("part_number", "0")),
+                "total_parts": int(file_elem.get("total_parts", "0")),
             }
-            parts.append((meta, units, tree.docinfo.encoding))
+            parsed_parts.append((meta, tree))
 
-        total_parts = parts[0][0]['total_parts']
-        file_id = parts[0][0]['file_id']
-        if len(parts) != total_parts:
+        total_parts = parsed_parts[0][0]["total_parts"]
+        file_id = parsed_parts[0][0]["file_id"]
+        if len(parsed_parts) != total_parts:
             raise ValueError("Missing parts")
-        for meta, _, _ in parts:
-            if meta['file_id'] != file_id or meta['total_parts'] != total_parts:
+        for meta, _ in parsed_parts:
+            if meta["file_id"] != file_id or meta["total_parts"] != total_parts:
                 raise ValueError("Inconsistent parts")
-        # sort by part_number
-        parts.sort(key=lambda x: x[0]['part_number'])
-        base_tree = etree.parse(str(part_paths[0]))
+
+        parsed_parts.sort(key=lambda x: x[0]["part_number"])
+
+        base_tree = deepcopy(parsed_parts[0][1])
         base_root = base_tree.getroot()
         base_file = base_root.find(".//{*}file")
         base_body = base_file.find(".//{*}body")
-        for child in list(base_body):
-            base_body.remove(child)
-        total = len(parts)
-        for idx, (_, units, _) in enumerate(parts):
-            for u in units:
-                base_body.append(deepcopy(u))
-            if progress_callback:
-                progress_callback(int((idx + 1) / total * 100), f"part {idx + 1}")
-            if should_stop_callback and should_stop_callback():
-                break
-        encoding = parts[0][2] or 'utf-8'
-        with open(output_path, 'wb') as f:
+
+        def clear_units(elem: etree._Element) -> None:
+            for child in list(elem):
+                if _is_group(child):
+                    clear_units(child)
+                elif _is_trans_unit(child):
+                    elem.remove(child)
+
+        clear_units(base_body)
+
+        units_by_path: Dict[str, List[Tuple[int, etree._Element]]] = defaultdict(list)
+
+        def collect(elem: etree._Element, path: List[str]) -> None:
+            group_counter = 0
+            for idx, child in enumerate(list(elem)):
+                if _is_group(child):
+                    ident = child.get("id") or f"idx{group_counter}"
+                    group_counter += 1
+                    collect(child, path + [ident])
+                elif _is_trans_unit(child):
+                    p = child.get(f"{{{SPLIT_NS}}}path")
+                    pos = child.get(f"{{{SPLIT_NS}}}pos")
+                    gpath = tuple(p.split("/")) if p else tuple(path)
+                    index = int(pos) if pos is not None else idx
+                    units_by_path["/".join(gpath)].append((index, deepcopy(child)))
+
+        for meta, tree in parsed_parts:
+            part_body = tree.getroot().find(".//{*}body")
+            collect(part_body, [])
+
+        def find_group(current: etree._Element, tokens: List[str]) -> etree._Element:
+            elem = current
+            for token in tokens:
+                group_idx = 0
+                found = None
+                for child in elem:
+                    if _is_group(child):
+                        gid = child.get("id")
+                        if gid == token:
+                            found = child
+                            break
+                        if gid is None and token.startswith("idx") and group_idx == int(token[3:]):
+                            found = child
+                            break
+                        group_idx += 1
+                if found is None:
+                    raise ValueError(f"Group path {'/'.join(tokens)} not found")
+                elem = found
+            return elem
+
+        for gpath, items in units_by_path.items():
+            group_elem = find_group(base_body, [t for t in gpath.split("/") if t])
+            items.sort(key=lambda x: x[0])
+            for index, unit in items:
+                unit.attrib.pop(f"{{{SPLIT_NS}}}path", None)
+                unit.attrib.pop(f"{{{SPLIT_NS}}}pos", None)
+                group_elem.insert(index, unit)
+
+        # clean metadata attributes from <file>
+        for attr in [
+            "original_file_id",
+            "part_number",
+            "total_parts",
+            "split_timestamp",
+            "segments_in_part",
+            "words_in_part",
+        ]:
+            if attr in base_file.attrib:
+                base_file.attrib.pop(attr)
+
+        etree.cleanup_namespaces(base_tree)
+
+        encoding = parsed_parts[0][1].docinfo.encoding or "utf-8"
+        with open(output_path, "wb") as f:
             base_tree.write(f, encoding=encoding, xml_declaration=True)
+
+        if progress_callback:
+            progress_callback(100, "merged")
         return output_path

--- a/tests/test_sdxliff_groups.py
+++ b/tests/test_sdxliff_groups.py
@@ -1,0 +1,66 @@
+from pathlib import Path
+from services.split_service import SplitService
+
+SAMPLE_GROUPS = '''<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:sdl="http://sdl.com/FileTypes/SdlXliff/1.0">
+  <file original="test" source-language="en-US" target-language="fr-FR">
+    <body>
+      <group id="g1">
+        <sdl:cxts>ctx</sdl:cxts>
+        <trans-unit id="1"><source>A</source><target>a</target></trans-unit>
+        <group id="g2">
+          <trans-unit id="2"><source>B</source><target>b</target></trans-unit>
+        </group>
+      </group>
+      <trans-unit id="3"><source>C</source><target>c</target></trans-unit>
+    </body>
+  </file>
+</xliff>'''
+
+SAMPLE_DEEP = '''<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+  <file original="test" source-language="en" target-language="fr">
+    <body>
+      <group id="a">
+        <group id="b">
+          <group id="c">
+            <trans-unit id="1"><source>a</source><target>a</target></trans-unit>
+            <trans-unit id="2"><source>b</source><target>b</target></trans-unit>
+          </group>
+        </group>
+      </group>
+    </body>
+  </file>
+</xliff>'''
+
+def _write_sample(path: Path, text: str) -> Path:
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def test_recursive_split_and_merge(tmp_path: Path):
+    src = _write_sample(tmp_path / "sample.sdxliff", SAMPLE_GROUPS)
+    service = SplitService()
+    info = service.analyze(src)
+    assert info["segments"] == 3
+
+    parts = service.split(src, parts=2)
+    merged = tmp_path / "merged.sdxliff"
+    service.merge(parts, merged)
+
+    from lxml import etree
+    orig = etree.tostring(etree.parse(str(src)), method="c14n")
+    merged_data = etree.tostring(etree.parse(str(merged)), method="c14n")
+    assert orig == merged_data
+
+
+def test_deep_groups(tmp_path: Path):
+    src = _write_sample(tmp_path / "deep.sdxliff", SAMPLE_DEEP)
+    service = SplitService()
+    parts = service.split(src, parts=2)
+    merged = tmp_path / "merged.sdxliff"
+    service.merge(parts, merged)
+    from lxml import etree
+    orig = etree.tostring(etree.parse(str(src)), method="c14n")
+    merged_data = etree.tostring(etree.parse(str(merged)), method="c14n")
+    assert orig == merged_data


### PR DESCRIPTION
## Summary
- add recursive parsing helpers and metadata for SDXLIFF splitting
- preserve group paths when splitting and rebuild nested groups on merge
- clean up merge metadata and namespaces
- test nested groups and deep hierarchy handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b895b469c832c9bddf5d441c2cde5