### PR TITLE
Add SDLXLIFF byte-preserving splitter and merger

### DIFF
--- a/core/splitters/__init__.py
+++ b/core/splitters/__init__.py
@@ -1,0 +1,2 @@
+from .sdlxliff_splitter import SdlxliffSplitter
+from .sdlxliff_merger import SdlxliffMerger

--- a/core/splitters/sdlxliff_merger.py
+++ b/core/splitters/sdlxliff_merger.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict
+
+from .sdlxliff_utils import (
+    parse_sdlxliff,
+    read_text,
+    reconstruct_sdlxliff,
+    write_text,
+    str_to_bom,
+)
+
+
+class SdlxliffMerger:
+    def merge(self, parts_dir: Path, output_file: Path) -> Path:
+        info_files = list(Path(parts_dir).glob('*.split-info.json'))
+        if not info_files:
+            raise FileNotFoundError('split-info.json not found')
+        info = json.loads(info_files[0].read_text(encoding='utf-8'))
+
+        header = info['header']
+        pres = info['pre_segments']
+        tail = info['tail']
+        encoding = info['encoding']
+        bom = str_to_bom(info['bom'])
+        total_segments = len(pres) - 1
+
+        segments: Dict[int, str] = {}
+        for part in info['parts']:
+            part_path = Path(parts_dir) / part['file']
+            text, _, _ = read_text(part_path)
+            _, _, segs, _ = parse_sdlxliff(text)
+            if len(segs) != len(part['segment_indexes']):
+                raise ValueError('Part segment count mismatch')
+            for idx, seg in zip(part['segment_indexes'], segs):
+                segments[idx] = seg
+
+        if len(segments) != total_segments:
+            raise ValueError('Missing segments for merge')
+
+        ordered = [segments[i] for i in range(total_segments)]
+        merged_text = reconstruct_sdlxliff(header, pres, ordered, tail)
+        write_text(output_file, merged_text, encoding, bom)
+        return output_file

--- a/core/splitters/sdlxliff_splitter.py
+++ b/core/splitters/sdlxliff_splitter.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import List, Set
+
+from lxml import etree
+
+from .sdlxliff_utils import (
+    bom_to_str,
+    md5_bytes,
+    parse_sdlxliff,
+    read_text,
+    reconstruct_sdlxliff,
+    write_text,
+)
+
+
+def count_words(text: str) -> int:
+    return len(re.findall(r"\w+", text))
+
+
+class SdlxliffSplitter:
+    def split(
+        self,
+        file_path: Path,
+        parts_count: int,
+        output_dir: Path,
+        *,
+        by_words: bool = False,
+    ) -> List[Path]:
+        text, encoding, bom = read_text(file_path)
+        header, pres, segments, tail = parse_sdlxliff(text)
+
+        # compute words per segment
+        words = []
+        parser = etree.XMLParser(remove_blank_text=False, strip_cdata=False)
+        for seg in segments:
+            elem = etree.fromstring(seg.encode("utf-8"), parser)
+            src = elem.find('.//{*}source')
+            seg_text = "" if src is None else "".join(src.itertext())
+            words.append(count_words(seg_text))
+
+        total_segments = len(segments)
+        total_words = sum(words)
+        if parts_count < 1:
+            raise ValueError('parts_count must be >=1')
+        if by_words:
+            target = total_words // parts_count
+            assignments: List[Set[int]] = []
+            idx = 0
+            for p in range(parts_count):
+                part_words = 0
+                indices: Set[int] = set()
+                while idx < total_segments and (part_words < target or not indices):
+                    indices.add(idx)
+                    part_words += words[idx]
+                    idx += 1
+                assignments.append(indices)
+            if idx < total_segments:
+                assignments[-1].update(range(idx, total_segments))
+        else:
+            base = total_segments // parts_count
+            remainder = total_segments % parts_count
+            assignments = []
+            start = 0
+            for p in range(parts_count):
+                count = base + (1 if p < remainder else 0)
+                indices = set(range(start, start + count))
+                assignments.append(indices)
+                start += count
+
+        original_md5 = md5_bytes(file_path.read_bytes())
+        info = {
+            "bom": bom_to_str(bom),
+            "encoding": encoding,
+            "header": header,
+            "pre_segments": pres,
+            "tail": tail,
+            "original_md5": original_md5,
+            "parts": [],
+        }
+
+        output_dir.mkdir(parents=True, exist_ok=True)
+        part_paths: List[Path] = []
+        for idx, indices in enumerate(assignments, 1):
+            part_text = reconstruct_sdlxliff(header, pres, segments, tail, indices)
+            part_name = f"{file_path.stem}.part{idx}{file_path.suffix}"
+            part_path = output_dir / part_name
+            write_text(part_path, part_text, encoding, bom)
+            part_paths.append(part_path)
+            info["parts"].append({"file": part_name, "segment_indexes": sorted(indices)})
+
+        info_path = output_dir / f"{file_path.name}.split-info.json"
+        with open(info_path, "w", encoding="utf-8") as f:
+            json.dump(info, f, ensure_ascii=False, indent=2)
+
+        return part_paths

--- a/core/splitters/sdlxliff_utils.py
+++ b/core/splitters/sdlxliff_utils.py
@@ -1,0 +1,91 @@
+import hashlib
+import json
+import re
+from pathlib import Path
+from typing import Optional, Tuple
+
+
+BOM_UTF8 = b"\xef\xbb\xbf"
+BOM_UTF16_LE = b"\xff\xfe"
+BOM_UTF16_BE = b"\xfe\xff"
+
+
+def detect_bom(data: bytes) -> Tuple[Optional[bytes], str]:
+    if data.startswith(BOM_UTF8):
+        return BOM_UTF8, "utf-8"
+    if data.startswith(BOM_UTF16_LE):
+        return BOM_UTF16_LE, "utf-16le"
+    if data.startswith(BOM_UTF16_BE):
+        return BOM_UTF16_BE, "utf-16be"
+    return None, "utf-8"
+
+
+def bom_to_str(bom: Optional[bytes]) -> str:
+    return bom.hex() if bom else ""
+
+
+def str_to_bom(s: str) -> Optional[bytes]:
+    return bytes.fromhex(s) if s else None
+
+
+def read_text(path: Path) -> Tuple[str, str, Optional[bytes]]:
+    data = path.read_bytes()
+    bom, encoding = detect_bom(data)
+    if bom:
+        data = data[len(bom) :]
+    else:
+        m = re.search(br"encoding=['\"]([^'\"]+)['\"]", data[:100])
+        if m:
+            encoding = m.group(1).decode("ascii", errors="ignore")
+    text = data.decode(encoding)
+    return text, encoding, bom
+
+
+def write_text(path: Path, text: str, encoding: str, bom: Optional[bytes]) -> None:
+    data = text.encode(encoding)
+    with open(path, "wb") as f:
+        if bom:
+            f.write(bom)
+        f.write(data)
+
+
+def md5_bytes(data: bytes) -> str:
+    return hashlib.md5(data).hexdigest()
+
+
+TRANS_UNIT_RE = re.compile(
+    r"<(?:[\w.-]+:)?trans-unit\b[^>]*>.*?</(?:[\w.-]+:)?trans-unit>", re.DOTALL
+)
+BODY_START_RE = re.compile(r"<(?:[\w.-]+:)?body\b[^>]*>")
+BODY_END_RE = re.compile(r"</(?:[\w.-]+:)?body>")
+
+
+def parse_sdlxliff(text: str) -> Tuple[str, list[str], list[str], str]:
+    start_m = BODY_START_RE.search(text)
+    end_m = BODY_END_RE.search(text)
+    if not start_m or not end_m:
+        raise ValueError("No <body> element found")
+    header = text[: start_m.end()]
+    body_content = text[start_m.end() : end_m.start()]
+    tail = text[end_m.start() :]
+
+    segments: list[str] = []
+    pres: list[str] = []
+    pos = 0
+    for m in TRANS_UNIT_RE.finditer(body_content):
+        pres.append(body_content[pos : m.start()])
+        segments.append(m.group(0))
+        pos = m.end()
+    pres.append(body_content[pos:])
+    return header, pres, segments, tail
+
+
+def reconstruct_sdlxliff(header: str, pres: list[str], segs: list[str], tail: str, include: Optional[set[int]] = None) -> str:
+    include = include or set(range(len(segs)))
+    parts = [header, pres[0]]
+    for i, seg in enumerate(segs):
+        if i in include:
+            parts.append(seg)
+        parts.append(pres[i + 1])
+    parts.append(tail)
+    return "".join(parts)

--- a/tests/test_sdlxliff_split_merge.py
+++ b/tests/test_sdlxliff_split_merge.py
@@ -1,0 +1,73 @@
+from pathlib import Path
+from core.splitters import SdlxliffSplitter, SdlxliffMerger
+from core.splitters.sdlxliff_utils import md5_bytes
+
+
+def _write(path: Path, text: str, encoding: str = "utf-8", bom: bool = False) -> Path:
+    data = text.encode(encoding)
+    if bom:
+        if encoding.lower().startswith("utf-16le"):
+            data = b"\xff\xfe" + data
+        elif encoding.lower().startswith("utf-16be"):
+            data = b"\xfe\xff" + data
+        else:
+            data = b"\xef\xbb\xbf" + data
+    path.write_bytes(data)
+    return path
+
+
+def _basic_sample() -> str:
+    return (
+        "<?xml version='1.0' encoding='UTF-8'?>\n"
+        "<xliff version='1.2' xmlns='urn:oasis:names:tc:xliff:document:1.2'>\n"
+        "  <file original='test' source-language='en' target-language='fr'>\n"
+        "    <body>\n"
+        "      <group id='g1'>\n"
+        "        <trans-unit id='1'><source>A</source><target>a</target></trans-unit>\n"
+        "        <trans-unit id='2'><source>B</source><target>b</target></trans-unit>\n"
+        "      </group>\n"
+        "      <trans-unit id='3'><source>C</source><target>c</target></trans-unit>\n"
+        "    </body>\n"
+        "  </file>\n"
+        "</xliff>\n"
+    )
+
+
+def test_split_merge_utf8(tmp_path: Path):
+    src = _write(tmp_path / "sample.sdlxliff", _basic_sample(), "utf-8", False)
+    splitter = SdlxliffSplitter()
+    parts = splitter.split(src, 2, tmp_path)
+    merger = SdlxliffMerger()
+    out = tmp_path / "merged.sdlxliff"
+    merger.merge(tmp_path, out)
+    assert md5_bytes(src.read_bytes()) == md5_bytes(out.read_bytes())
+
+
+def test_split_merge_utf16(tmp_path: Path):
+    src = _write(tmp_path / "sample_utf16.sdlxliff", _basic_sample(), "utf-16le", True)
+    splitter = SdlxliffSplitter()
+    parts = splitter.split(src, 3, tmp_path)
+    merger = SdlxliffMerger()
+    out = tmp_path / "merged.sdlxliff"
+    merger.merge(tmp_path, out)
+    assert md5_bytes(src.read_bytes()) == md5_bytes(out.read_bytes())
+
+
+def test_large_file(tmp_path: Path):
+    segments = []
+    for i in range(1, 1001):
+        segments.append(f"<trans-unit id='{i}'><source>S{i}</source><target>T{i}</target></trans-unit>")
+    body = "\n".join(segments)
+    sample = (
+        "<?xml version='1.0' encoding='UTF-8'?>\n"
+        "<xliff version='1.2' xmlns='urn:oasis:names:tc:xliff:document:1.2'>\n"
+        "  <file original='t' source-language='en' target-language='fr'>\n"
+        "    <body>\n" + body + "\n    </body>\n  </file>\n</xliff>\n"
+    )
+    src = _write(tmp_path / "big.sdlxliff", sample)
+    splitter = SdlxliffSplitter()
+    splitter.split(src, 5, tmp_path)
+    merger = SdlxliffMerger()
+    out = tmp_path / "merged.sdlxliff"
+    merger.merge(tmp_path, out)
+    assert md5_bytes(src.read_bytes()) == md5_bytes(out.read_bytes())


### PR DESCRIPTION
## Summary
- implement new `SdlxliffSplitter` and `SdlxliffMerger` that retain the original bytes
- store BOM and formatting data externally in `.split-info.json`
- provide utils for BOM handling and reconstruction
- add comprehensive tests verifying round‑trip integrity for UTF‑8/UTF‑16 and large files

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686bc084d4d0832caacb5eb843110974