### PR TITLE
Handle missing split-info for mergers

### DIFF
--- a/core/splitters/sdlxliff_merger.py
+++ b/core/splitters/sdlxliff_merger.py
@@ -16,31 +16,47 @@ from .sdlxliff_utils import (
 class SdlxliffMerger:
     def merge(self, parts_dir: Path, output_file: Path) -> Path:
         info_files = list(Path(parts_dir).glob('*.split-info.json'))
-        if not info_files:
-            raise FileNotFoundError('split-info.json not found')
-        info = json.loads(info_files[0].read_text(encoding='utf-8'))
+        if info_files:
+            info = json.loads(info_files[0].read_text(encoding='utf-8'))
 
-        header = info['header']
-        pres = info['pre_segments']
-        tail = info['tail']
-        encoding = info['encoding']
-        bom = str_to_bom(info['bom'])
-        total_segments = len(pres) - 1
+            header = info['header']
+            pres = info['pre_segments']
+            tail = info['tail']
+            encoding = info['encoding']
+            bom = str_to_bom(info['bom'])
+            total_segments = len(pres) - 1
 
-        segments: Dict[int, str] = {}
-        for part in info['parts']:
-            part_path = Path(parts_dir) / part['file']
-            text, _, _ = read_text(part_path)
+            segments: Dict[int, str] = {}
+            for part in info['parts']:
+                part_path = Path(parts_dir) / part['file']
+                text, _, _ = read_text(part_path)
+                _, _, segs, _ = parse_sdlxliff(text)
+                if len(segs) != len(part['segment_indexes']):
+                    raise ValueError('Part segment count mismatch')
+                for idx, seg in zip(part['segment_indexes'], segs):
+                    segments[idx] = seg
+
+            if len(segments) != total_segments:
+                raise ValueError('Missing segments for merge')
+
+            ordered = [segments[i] for i in range(total_segments)]
+            merged_text = reconstruct_sdlxliff(header, pres, ordered, tail)
+            write_text(output_file, merged_text, encoding, bom)
+            return output_file
+
+        # Fallback: merge without split-info.json
+        part_paths = sorted(Path(parts_dir).glob('*.sdlxliff'))
+        if not part_paths:
+            raise FileNotFoundError('No parts provided')
+        text, encoding, bom = read_text(part_paths[0])
+        header, _, _, tail = parse_sdlxliff(text)
+        all_segments = []
+        for p in part_paths:
+            text, _, _ = read_text(p)
             _, _, segs, _ = parse_sdlxliff(text)
-            if len(segs) != len(part['segment_indexes']):
-                raise ValueError('Part segment count mismatch')
-            for idx, seg in zip(part['segment_indexes'], segs):
-                segments[idx] = seg
+            all_segments.extend(segs)
 
-        if len(segments) != total_segments:
-            raise ValueError('Missing segments for merge')
-
-        ordered = [segments[i] for i in range(total_segments)]
-        merged_text = reconstruct_sdlxliff(header, pres, ordered, tail)
+        pres = ["" for _ in range(len(all_segments) + 1)]
+        merged_text = reconstruct_sdlxliff(header, pres, all_segments, tail)
         write_text(output_file, merged_text, encoding, bom)
         return output_file

--- a/core/splitters/sdxliff_merger.py
+++ b/core/splitters/sdxliff_merger.py
@@ -29,32 +29,48 @@ class SdxliffMerger:
 
         parts_dir = part_paths[0].parent
         info_files = list(parts_dir.glob('*.split-info.json'))
-        if not info_files:
-            raise FileNotFoundError('split-info.json not found')
-        info = json.loads(info_files[0].read_text(encoding='utf-8'))
+        if info_files:
+            info = json.loads(info_files[0].read_text(encoding='utf-8'))
 
-        header = info['header']
-        pres = info['pre_segments']
-        tail = info['tail']
-        encoding = info['encoding']
-        bom = str_to_bom(info['bom'])
-        total_segments = len(pres) - 1
+            header = info['header']
+            pres = info['pre_segments']
+            tail = info['tail']
+            encoding = info['encoding']
+            bom = str_to_bom(info['bom'])
+            total_segments = len(pres) - 1
 
-        segments: Dict[int, str] = {}
-        for part in info['parts']:
-            part_path = parts_dir / part['file']
-            text, _, _ = read_text(part_path)
+            segments: Dict[int, str] = {}
+            for part in info['parts']:
+                part_path = parts_dir / part['file']
+                text, _, _ = read_text(part_path)
+                _, _, segs, _ = parse_sdxliff(text)
+                if len(segs) != len(part['segment_indexes']):
+                    raise ValueError('Part segment count mismatch')
+                for idx, seg in zip(part['segment_indexes'], segs):
+                    segments[idx] = seg
+
+            if len(segments) != total_segments:
+                raise ValueError('Missing segments for merge')
+
+            ordered = [segments[i] for i in range(total_segments)]
+            merged_text = reconstruct_sdxliff(header, pres, ordered, tail)
+            write_text(output_file, merged_text, encoding, bom)
+            if progress_callback:
+                progress_callback(100, "merged")
+            return output_file
+
+        # Fallback: merge without split-info.json
+        part_paths = sorted(part_paths)
+        text, encoding, bom = read_text(part_paths[0])
+        header, _, _, tail = parse_sdxliff(text)
+        all_segments = []
+        for path in part_paths:
+            text, _, _ = read_text(path)
             _, _, segs, _ = parse_sdxliff(text)
-            if len(segs) != len(part['segment_indexes']):
-                raise ValueError('Part segment count mismatch')
-            for idx, seg in zip(part['segment_indexes'], segs):
-                segments[idx] = seg
+            all_segments.extend(segs)
 
-        if len(segments) != total_segments:
-            raise ValueError('Missing segments for merge')
-
-        ordered = [segments[i] for i in range(total_segments)]
-        merged_text = reconstruct_sdxliff(header, pres, ordered, tail)
+        pres = ["" for _ in range(len(all_segments) + 1)]
+        merged_text = reconstruct_sdxliff(header, pres, all_segments, tail)
         write_text(output_file, merged_text, encoding, bom)
         if progress_callback:
             progress_callback(100, "merged")


### PR DESCRIPTION
## Summary
- allow merging SDXLIFF/SDLXLIFF parts even if `.split-info.json` is absent
- fall back to basic concatenation of parts when metadata file missing

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'langcodes' and 'lxml')*

------
https://chatgpt.com/codex/tasks/task_e_686bed70f02c832ca9dd0a9a26febf9e