### PR TITLE
Add SDLXLIFF split/merge utilities

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,0 +1,4 @@
+from .splitter import Splitter
+from .merger import Merger
+
+__all__ = ['Splitter', 'Merger']

--- a/core/merger.py
+++ b/core/merger.py
@@ -1,0 +1,11 @@
+from typing import List
+
+class Merger:
+    """Bit-perfect SDLXLIFF merger."""
+
+    def __init__(self, parts_bytes: List[bytes]):
+        self.parts = parts_bytes
+
+    def merge(self) -> bytes:
+        """Return concatenated bytes of all parts."""
+        return b"".join(self.parts)

--- a/core/splitter.py
+++ b/core/splitter.py
@@ -1,0 +1,45 @@
+import re
+from typing import List
+
+class Splitter:
+    """Bit-perfect splitter for SDLXLIFF files."""
+
+    def __init__(self, xml_bytes: bytes):
+        self.xml_bytes = xml_bytes
+        self.group_matches = list(re.finditer(br'<group\b[\s\S]*?</group>', xml_bytes))
+        if not self.group_matches:
+            raise ValueError("Файл не содержит <group>")
+        self.fragments = self._get_raw_fragments()
+
+    def _get_raw_fragments(self) -> List[bytes]:
+        """Return [gap0], [group0], [gap1], [group1], ..., [gapN], [footer]."""
+        frags = []
+        prev_end = 0
+        for m in self.group_matches:
+            start, end = m.start(), m.end()
+            frags.append(self.xml_bytes[prev_end:start])
+            frags.append(self.xml_bytes[start:end])
+            prev_end = end
+        frags.append(self.xml_bytes[prev_end:])
+        return frags
+
+    def split_by_parts(self, num_parts: int) -> List[bytes]:
+        """Split file by groups preserving gaps byte-for-byte."""
+        group_count = len(self.group_matches)
+        groups_per_part = [
+            group_count // num_parts + (1 if x < group_count % num_parts else 0)
+            for x in range(num_parts)
+        ]
+        parts = []
+        frag_idx = 1
+        for part_size in groups_per_part:
+            if frag_idx == 1:
+                part = [self.fragments[0]]
+            else:
+                part = [self.fragments[frag_idx - 1]]
+            for _ in range(part_size):
+                part.append(self.fragments[frag_idx])
+                part.append(self.fragments[frag_idx + 1])
+                frag_idx += 2
+            parts.append(b"".join(part))
+        return parts

--- a/tests/test_split_merge.py
+++ b/tests/test_split_merge.py
@@ -1,0 +1,22 @@
+from core import Splitter, Merger
+from utils import sort_split_filenames
+
+
+def test_split_merge_roundtrip():
+    xml = (
+        b"<file>header"
+        b"<group id='1'>A</group>"
+        b"<group id='2'>B</group>"
+        b"footer</file>"
+    )
+    splitter = Splitter(xml)
+    parts = splitter.split_by_parts(2)
+    merger = Merger(parts)
+    merged = merger.merge()
+    assert merged == xml
+
+
+def test_sort_split_filenames():
+    names = ["file.2of3.sdlxliff", "file.1of3.sdlxliff"]
+    sorted_names = sort_split_filenames(names)
+    assert sorted_names == ["file.1of3.sdlxliff", "file.2of3.sdlxliff"]

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,13 @@
+from .io_utils import (
+    make_split_filenames,
+    save_bytes_list,
+    read_bytes_list,
+    sort_split_filenames,
+)
+
+__all__ = [
+    'make_split_filenames',
+    'save_bytes_list',
+    'read_bytes_list',
+    'sort_split_filenames',
+]

--- a/utils/io_utils.py
+++ b/utils/io_utils.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+import re
+from typing import List
+
+
+def make_split_filenames(src_path: str, parts_count: int) -> List[str]:
+    p = Path(src_path)
+    name = p.stem
+    ext = p.suffix
+    parent = p.parent
+    return [
+        str(parent / f"{name}.{i+1}of{parts_count}{ext}")
+        for i in range(parts_count)
+    ]
+
+
+def save_bytes_list(files_bytes: List[bytes], filenames: List[str]) -> None:
+    for data, fname in zip(files_bytes, filenames):
+        with open(fname, "wb") as f:
+            f.write(data)
+
+
+def read_bytes_list(paths: List[str]) -> List[bytes]:
+    return [Path(p).read_bytes() for p in paths]
+
+
+def sort_split_filenames(file_list: List[str]) -> List[str]:
+    pattern = re.compile(r"\.(\d+)of(\d+)\.sdlxliff$", re.IGNORECASE)
+
+    def extract_idx(fname: str):
+        m = pattern.search(fname)
+        if m:
+            return int(m.group(1))
+        return float("inf")
+
+    return sorted(file_list, key=extract_idx)


### PR DESCRIPTION
## Summary
- implement `Splitter` and `Merger` in `core` for byte‑perfect SDLXLIFF handling
- add helper functions for managing split files in `utils.io_utils`
- expose new helpers through package `__init__` modules
- provide basic tests for split/merge logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68719349bbe4832ca4d5ec14764dc57b