### PR TITLE
Fix XML parser failures

### DIFF
--- a/core/splitters/sdxliff_merger.py
+++ b/core/splitters/sdxliff_merger.py
@@ -36,8 +36,9 @@ class SdxliffMerger:
 
         # parse all
         parts = []
+        parser = etree.XMLParser(recover=True)
         for p in part_paths:
-            tree = etree.parse(str(p))
+            tree = etree.parse(str(p), parser)
             root = tree.getroot()
             file_elem = root.find(".//{*}file")
             body = file_elem.find(".//{*}body")
@@ -58,7 +59,7 @@ class SdxliffMerger:
                 raise ValueError("Inconsistent parts")
         # sort by part_number
         parts.sort(key=lambda x: x[0]['part_number'])
-        base_tree = etree.parse(str(part_paths[0]))
+        base_tree = etree.parse(str(part_paths[0]), parser)
         base_root = base_tree.getroot()
         base_file = base_root.find(".//{*}file")
         base_body = base_file.find(".//{*}body")

--- a/core/splitters/sdxliff_splitter.py
+++ b/core/splitters/sdxliff_splitter.py
@@ -72,7 +72,7 @@ class SdxliffSplitter:
                 pass
 
         bom = _read_bom(filepath)
-        parser = etree.XMLParser(remove_blank_text=False)
+        parser = etree.XMLParser(remove_blank_text=False, recover=True)
         tree = etree.parse(str(filepath), parser)
         root = tree.getroot()
         file_elem = root.find(".//{*}file")

--- a/gui/dialogs/sdxliff_tools_dialog.py
+++ b/gui/dialogs/sdxliff_tools_dialog.py
@@ -198,9 +198,10 @@ class SdxliffToolsDialog(QDialog):
         try:
             from lxml import etree
 
+            parser = etree.XMLParser(recover=True)
             metas = []
             for f in files:
-                tree = etree.parse(str(f))
+                tree = etree.parse(str(f), parser)
                 file_elem = tree.getroot().find(".//{*}file")
                 metas.append(
                     (

--- a/gui/windows/sdxliff_split_window.py
+++ b/gui/windows/sdxliff_split_window.py
@@ -165,9 +165,10 @@ class SdxliffSplitWindow(QWidget):
         try:
             from lxml import etree
 
+            parser = etree.XMLParser(recover=True)
             metas = []
             for f in files:
-                tree = etree.parse(str(f))
+                tree = etree.parse(str(f), parser)
                 file_elem = tree.getroot().find(".//{*}file")
                 metas.append(
                     (

--- a/services/file_service.py
+++ b/services/file_service.py
@@ -165,7 +165,8 @@ class FileService:
         try:
             from lxml import etree
             from core.splitters.sdxliff_splitter import count_words
-            tree = etree.parse(str(filepath))
+            parser = etree.XMLParser(recover=True)
+            tree = etree.parse(str(filepath), parser)
             units = tree.findall(".//{*}trans-unit")
             words = 0
             for u in units:

--- a/services/split_service.py
+++ b/services/split_service.py
@@ -14,7 +14,7 @@ class SplitService:
         self.merger = SdxliffMerger()
 
     def analyze(self, filepath: Path) -> dict:
-        parser = etree.XMLParser(remove_blank_text=False)
+        parser = etree.XMLParser(remove_blank_text=False, recover=True)
         tree = etree.parse(str(filepath), parser)
         units = tree.findall(".//{*}trans-unit")
         word_count = 0


### PR DESCRIPTION
## Summary
- let lxml recover from malformed XML when splitting or merging
- allow GUI utilities to open slightly invalid SDXLIFF files

## Testing
- `pip install -r requirements.txt`
- `pip install langcodes`
- `pip install lxml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68755258204c832c89f6a5f088df03a0