### PR TITLE
Improve XLIFF splitting/merging

### DIFF
--- a/core/converters/sdlxliff_converter.py
+++ b/core/converters/sdlxliff_converter.py
@@ -145,11 +145,11 @@ class SdlxliffConverter(StreamingConverter):
 
             # Определяем метод разделения
             if settings.by_word_count:
-                progress_msg = "Разделение по " + str(settings.words_per_part) + " слов на часть..."
+                progress_msg = "Разделение на " + str(settings.parts_count) + " частей по словам..."
                 self._update_progress(30, progress_msg, options)
                 try:
-                    parts_content = splitter.split_by_word_count(settings.words_per_part)
-                    actual_parts = len(parts_content)
+                    parts_content = splitter.split_by_words(settings.parts_count)
+                    actual_parts = settings.parts_count
                 except Exception as e:
                     error_msg = f"Ошибка разделения по словам: {e}"
                     logger.error(error_msg)
@@ -258,7 +258,6 @@ class SdlxliffConverter(StreamingConverter):
                 "segments_total": split_info['total_segments'],
                 "words_total": split_info['total_words'],
                 "by_word_count": settings.by_word_count,
-                "words_per_part": settings.words_per_part if settings.by_word_count else None,
                 "preserve_groups": settings.preserve_groups,
                 "split_id": split_info['split_id'],
                 "encoding": split_info['encoding'],

--- a/sdlxliff_split_merge/__init__.py
+++ b/sdlxliff_split_merge/__init__.py
@@ -8,6 +8,7 @@ from .splitter import StructuralSplitter
 from .merger import StructuralMerger
 from .validator import SdlxliffValidator
 from .io_utils import make_split_filenames, save_bytes_list, read_bytes_list, sort_split_filenames
+from .target_merge import merge_with_original
 from .xml_utils import TransUnitParser, XmlStructure
 
 # Импорты для обратной совместимости с main.py
@@ -26,6 +27,7 @@ __all__ = [
     "save_bytes_list",
     "read_bytes_list",
     "sort_split_filenames",
+    "merge_with_original",
     # Старые имена для совместимости
     "Splitter",
     "Merger"

--- a/sdlxliff_split_merge/logger.py
+++ b/sdlxliff_split_merge/logger.py
@@ -1,9 +1,24 @@
 import logging
+from logging.handlers import RotatingFileHandler
 
-def setup_logger(logfile='split_merge.log'):
+
+def setup_logger(logfile: str = "split_merge.log") -> logging.Logger:
+    """Configure root logger for console and file output."""
     logging.basicConfig(
         level=logging.INFO,
         format="%(asctime)s %(levelname)s: %(message)s",
-        handlers=[logging.FileHandler(logfile, encoding='utf-8'), logging.StreamHandler()]
+        handlers=[logging.FileHandler(logfile, encoding="utf-8"), logging.StreamHandler()],
     )
     return logging.getLogger("splitmerge")
+
+
+def get_file_logger(logfile: str = "split_merge_details.log") -> logging.Logger:
+    """Return a dedicated logger writing to ``logfile``."""
+    logger = logging.getLogger(f"splitmerge.{logfile}")
+    if not logger.handlers:
+        handler = RotatingFileHandler(logfile, maxBytes=500000, backupCount=3, encoding="utf-8")
+        formatter = logging.Formatter("%(asctime)s %(levelname)s: %(message)s")
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+        logger.setLevel(logging.INFO)
+    return logger

--- a/sdlxliff_split_merge/target_merge.py
+++ b/sdlxliff_split_merge/target_merge.py
@@ -1,0 +1,64 @@
+import re
+from typing import List, Dict
+import logging
+
+from .xml_utils import XmlStructure
+from .logger import get_file_logger
+
+
+logger = logging.getLogger(__name__)
+
+
+def _extract_targets(parts: List[str], log) -> Dict[str, str]:
+    mapping: Dict[str, str] = {}
+    tu_pattern = re.compile(r'<trans-unit\s+[^>]*id=["\']([^"\']+)["\'][^>]*>(.*?)</trans-unit>', re.DOTALL)
+    tgt_pattern = re.compile(r'<target[^>]*>.*?</target>', re.DOTALL)
+
+    for idx, content in enumerate(parts, 1):
+        for m in tu_pattern.finditer(content):
+            unit_id = m.group(1)
+            target_m = tgt_pattern.search(m.group(0))
+            if not target_m:
+                log.warning(f"Part {idx}: segment {unit_id} has no target")
+                continue
+            if unit_id in mapping:
+                log.warning(f"Duplicate translation for id {unit_id} in part {idx}")
+            mapping[unit_id] = target_m.group(0)
+    log.info(f"Collected targets for {len(mapping)} segments")
+    return mapping
+
+
+def _replace_target(xml: str, new_target: str) -> str:
+    if re.search(r'<target[^>]*>.*?</target>', xml, re.DOTALL):
+        return re.sub(r'<target[^>]*>.*?</target>', new_target, xml, count=1, flags=re.DOTALL)
+    return re.sub(r'(</trans-unit>)', new_target + r'\1', xml, count=1, flags=re.DOTALL)
+
+
+def merge_with_original(original_content: str, parts_content: List[str], log_file: str = "merge_details.log") -> str:
+    """Merge translations from ``parts_content`` into ``original_content``."""
+    log = get_file_logger(log_file)
+    structure = XmlStructure(original_content)
+    replacements = _extract_targets(parts_content, log)
+
+    result_parts = []
+    last_pos = 0
+    updated = 0
+
+    for unit in structure.trans_units:
+        result_parts.append(original_content[last_pos:unit.start_pos])
+        if unit.id in replacements:
+            new_unit = _replace_target(unit.full_xml, replacements[unit.id])
+            if new_unit == unit.full_xml:
+                log.error(f"Failed to insert translation for id {unit.id}")
+            else:
+                log.info(f"Segment {unit.id} updated")
+                updated += 1
+            result_parts.append(new_unit)
+        else:
+            log.debug(f"Segment {unit.id} not found in parts")
+            result_parts.append(unit.full_xml)
+        last_pos = unit.end_pos
+
+    result_parts.append(original_content[last_pos:])
+    log.info(f"Merge finished, {updated} segments updated")
+    return "".join(result_parts)

--- a/tests/test_sdlxliff_merge.py
+++ b/tests/test_sdlxliff_merge.py
@@ -1,0 +1,38 @@
+import re
+from sdlxliff_split_merge import StructuralSplitter, merge_with_original
+
+SAMPLE_ORIG = """
+<xliff xmlns='urn:oasis:names:tc:xliff:document:1.2'><file><header></header><body>
+<trans-unit id="1"><source>one two three</source><target/></trans-unit>
+<trans-unit id="2"><source>four five six seven</source><target/></trans-unit>
+<trans-unit id="3"><source>eight nine</source><target/></trans-unit>
+<trans-unit id="4"><source>ten</source><target/></trans-unit>
+</body></file></xliff>
+"""
+
+
+def test_split_by_words():
+    splitter = StructuralSplitter(SAMPLE_ORIG)
+    parts = splitter.split_by_words(2)
+    assert len(parts) == 2
+    # first part should contain first two segments
+    assert re.search(r'id="1"', parts[0])
+    assert re.search(r'id="2"', parts[0])
+
+
+def test_merge_with_original():
+    parts = [
+        "<xliff><file><body>"
+        "<trans-unit id='1'><source>one two three</source><target>uno</target></trans-unit>"
+        "<trans-unit id='2'><source>four five six seven</source><target>dos</target></trans-unit>"
+        "</body></file></xliff>",
+        "<xliff><file><body>"
+        "<trans-unit id='3'><source>eight nine</source><target>tres</target></trans-unit>"
+        "<trans-unit id='4'><source>ten</source><target>cuatro</target></trans-unit>"
+        "</body></file></xliff>",
+    ]
+    merged = merge_with_original(SAMPLE_ORIG, parts)
+    assert "<target>uno</target>" in merged
+    assert "<target>dos</target>" in merged
+    assert "<target>tres</target>" in merged
+    assert "<target>cuatro</target>" in merged


### PR DESCRIPTION
## Summary
- provide detailed file logger
- allow splitting by number of words
- implement merging that replaces targets in the original file
- update converter to use new method
- test new split/merge behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687986b8ef5c832ca705f3140184a407