### PR TITLE
Add original detection and merge logging

### DIFF
--- a/sdlxliff_split_merge/__init__.py
+++ b/sdlxliff_split_merge/__init__.py
@@ -7,7 +7,13 @@ SDLXLIFF Split/Merge Module - Структурное разделение с п�
 from .splitter import StructuralSplitter
 from .merger import StructuralMerger
 from .validator import SdlxliffValidator
-from .io_utils import make_split_filenames, save_bytes_list, read_bytes_list, sort_split_filenames
+from .io_utils import (
+    make_split_filenames,
+    save_bytes_list,
+    read_bytes_list,
+    sort_split_filenames,
+    load_original_and_parts,
+)
 from .merger import merge_with_original
 from .xml_utils import TransUnitParser, XmlStructure
 
@@ -27,6 +33,7 @@ __all__ = [
     "save_bytes_list",
     "read_bytes_list",
     "sort_split_filenames",
+    "load_original_and_parts",
     "merge_with_original",
     # Старые имена для совместимости
     "Splitter",

--- a/tests/test_sdlxliff_merge.py
+++ b/tests/test_sdlxliff_merge.py
@@ -1,5 +1,9 @@
 import re
-from sdlxliff_split_merge import StructuralSplitter, merge_with_original
+from sdlxliff_split_merge import (
+    StructuralSplitter,
+    merge_with_original,
+    load_original_and_parts,
+)
 
 SAMPLE_ORIG = """
 <xliff xmlns='urn:oasis:names:tc:xliff:document:1.2'><file><header></header><body>
@@ -36,3 +40,23 @@ def test_merge_with_original():
     assert "<target>dos</target>" in merged
     assert "<target>tres</target>" in merged
     assert "<target>cuatro</target>" in merged
+
+
+def test_load_original_and_parts(tmp_path):
+    orig_path = tmp_path / "doc.sdlxliff"
+    orig_path.write_text(SAMPLE_ORIG, encoding="utf-8")
+
+    splitter = StructuralSplitter(SAMPLE_ORIG)
+    parts = splitter.split(2)
+    part_paths = []
+    for i, content in enumerate(parts, 1):
+        p = tmp_path / f"doc.{i}of2.sdlxliff"
+        p.write_text(content, encoding="utf-8")
+        part_paths.append(p)
+
+    all_paths = [str(part_paths[1]), str(orig_path), str(part_paths[0])]
+    original, loaded_parts = load_original_and_parts(all_paths)
+
+    assert original == SAMPLE_ORIG
+    assert len(loaded_parts) == 2
+    assert "1" in loaded_parts[0]


### PR DESCRIPTION
## Summary
- add helper to load original SDLXLIFF and translation parts
- expose helper in package API
- improve `merge_with_original` with detailed logging and structure checks
- test new loader function

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a11816c48832ca264afc916f808f4