### PR TITLE
Fix merging when split metadata removed

### DIFF
--- a/sdlxliff_split_merge/io_utils.py
+++ b/sdlxliff_split_merge/io_utils.py
@@ -5,6 +5,8 @@ import re
 import logging
 from typing import List, Tuple
 
+_SPLIT_PART_RE = re.compile(r"\.\d+of\d+\.sdlxliff$", re.IGNORECASE)
+
 logger = logging.getLogger(__name__)
 
 
@@ -67,7 +69,10 @@ def load_original_and_parts(paths: List[str]) -> Tuple[str, List[str]]:
     part_pairs = []
 
     for path, content in zip(paths, contents):
-        if validator.is_split_part(content):
+        name = Path(path).name
+        is_part = validator.is_split_part(content) or _SPLIT_PART_RE.search(name)
+
+        if is_part:
             part_pairs.append((path, content))
             logger.debug("%s recognised as split part", path)
         else:

--- a/tests/test_sdlxliff_merge.py
+++ b/tests/test_sdlxliff_merge.py
@@ -60,3 +60,26 @@ def test_load_original_and_parts(tmp_path):
     assert original == SAMPLE_ORIG
     assert len(loaded_parts) == 2
     assert "1" in loaded_parts[0]
+
+
+def test_load_parts_missing_metadata(tmp_path):
+    orig_path = tmp_path / "doc.sdlxliff"
+    orig_path.write_text(SAMPLE_ORIG, encoding="utf-8")
+
+    splitter = StructuralSplitter(SAMPLE_ORIG)
+    parts = splitter.split(2)
+    stripped = [
+        re.sub(r"<!-- SDLXLIFF_SPLIT_METADATA:.*?-->\s*", "", p, flags=re.DOTALL)
+        for p in parts
+    ]
+    part_paths = []
+    for i, content in enumerate(stripped, 1):
+        p = tmp_path / f"doc.{i}of2.sdlxliff"
+        p.write_text(content, encoding="utf-8")
+        part_paths.append(p)
+
+    all_paths = [str(orig_path), str(part_paths[0]), str(part_paths[1])]
+    original, loaded_parts = load_original_and_parts(all_paths)
+
+    assert original == SAMPLE_ORIG
+    assert len(loaded_parts) == 2


### PR DESCRIPTION
## Summary
- detect split SDLXLIFF parts by filename when metadata is missing
- test merge helper with parts missing split metadata

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687be59bc5d4832c92d8af603b8c02f5