### PR TITLE
Handle missing metadata when merging SDLXLIFF parts

### DIFF
--- a/tests/test_sdlxliff_merge.py
+++ b/tests/test_sdlxliff_merge.py
@@ -1,6 +1,7 @@
 import re
 from sdlxliff_split_merge import (
     StructuralSplitter,
+    StructuralMerger,
     merge_with_original,
     load_original_and_parts,
 )
@@ -110,3 +111,17 @@ def test_merge_worker_without_metadata(tmp_path):
     assert output_path.exists()
     content = output_path.read_text(encoding="utf-8")
     assert "one two three" in content
+
+
+def test_structural_merger_without_metadata():
+    splitter = StructuralSplitter(SAMPLE_ORIG)
+    parts = splitter.split(2)
+    stripped = [
+        re.sub(r"<!-- SDLXLIFF_SPLIT_METADATA:.*?-->\s*", "", p, flags=re.DOTALL)
+        for p in parts
+    ]
+
+    merger = StructuralMerger(stripped)
+    merged = merger.merge()
+
+    assert "one two three" in merged

--- a/workers/sdlxliff_worker.py
+++ b/workers/sdlxliff_worker.py
@@ -232,8 +232,15 @@ class SdlxliffMergeWorker(QThread):
 
             validator = SdlxliffValidator()
             metadata = validator._extract_split_metadata(parts_content[0])
-            original_name = metadata.get('original_name', 'merged.sdlxliff')
-            encoding = metadata.get('encoding', 'utf-8')
+            if metadata:
+                original_name = metadata.get('original_name', 'merged.sdlxliff')
+                encoding = metadata.get('encoding', 'utf-8')
+            else:
+                from sdlxliff_split_merge.xml_utils import XmlStructure
+
+                structure = XmlStructure(original_content)
+                original_name = 'merged.sdlxliff'
+                encoding = structure.encoding
 
             total_segments = len([1 for _ in re.finditer(r'<trans-unit[^>]*>', original_content)])
             translated_segments = len([1 for _ in re.finditer(r'<target[^>]*>.*?</target>', merged_content, re.DOTALL)])
@@ -270,7 +277,7 @@ class SdlxliffMergeWorker(QThread):
                 "translation_progress": (translated_segments / total_segments * 100) if total_segments > 0 else 0,
                 "output_size_mb": len(merged_content.encode(encoding)) / (1024 * 1024),
                 "original_file_used": True,
-                "split_id": metadata.get('split_id'),
+                "split_id": metadata.get('split_id') if metadata else None,
                 "original_name": original_name,
                 "encoding": encoding,
                 "log_file": log_file

--- a/workers/sdlxliff_worker.py
+++ b/workers/sdlxliff_worker.py
@@ -231,7 +231,7 @@ class SdlxliffMergeWorker(QThread):
             self.progress.emit(70, "Анализ результата...")
 
             validator = SdlxliffValidator()
-            metadata = validator._extract_split_metadata(parts_content[0])
+            metadata = validator._extract_split_metadata(parts_content[0]) or {}
             if metadata:
                 original_name = metadata.get('original_name', 'merged.sdlxliff')
                 encoding = metadata.get('encoding', 'utf-8')
@@ -277,7 +277,7 @@ class SdlxliffMergeWorker(QThread):
                 "translation_progress": (translated_segments / total_segments * 100) if total_segments > 0 else 0,
                 "output_size_mb": len(merged_content.encode(encoding)) / (1024 * 1024),
                 "original_file_used": True,
-                "split_id": metadata.get('split_id') if metadata else None,
+                "split_id": metadata.get('split_id'),
                 "original_name": original_name,
                 "encoding": encoding,
                 "log_file": log_file


### PR DESCRIPTION
## Summary
- avoid crash in `SdlxliffMergeWorker` when merging parts without metadata
- use original file encoding when metadata is absent
- test merge worker with parts missing metadata

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687beec5dbe0832c8bf618255173b9ac